### PR TITLE
Allow options to be provided via meta-tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ grover = Grover.new('https://google.com', page_size: 'A4')
 # Get an inline PDF
 pdf = grover.to_pdf
 
+# Options can be provided through meta tags
+Grover.new('<html><head><meta name="grover-page_ranges" content="1-3"')
+Grover.new('<html><head><meta name="grover-margin-top" content="10px"')
+# N.B. options are underscore case, and sub-options separated with a dash
+# N.B. #2 all options can be overwritten, including `emulate_media` and `display_url` 
 ```
 
 

--- a/lib/grover/configuration.rb
+++ b/lib/grover/configuration.rb
@@ -3,10 +3,11 @@ class Grover
   # Configuration of the options for Grover HTML to PDF conversion
   #
   class Configuration
-    attr_accessor :options
+    attr_accessor :options, :meta_tag_prefix
 
     def initialize
       @options = {}
+      @meta_tag_prefix = 'grover-'
     end
   end
 end

--- a/lib/grover/utils.rb
+++ b/lib/grover/utils.rb
@@ -31,6 +31,19 @@ class Grover
     end
 
     #
+    # Assign value to a hash using an array of keys to traverse
+    #
+    def self.deep_assign(hash, keys, value)
+      if keys.length == 1
+        hash[keys.first] = value
+      else
+        key = keys.shift
+        hash[key] ||= {}
+        deep_assign hash[key], keys, value
+      end
+    end
+
+    #
     # Recursively normalizes hash objects with camelized string keys
     #
     def self.normalize_object(object)

--- a/spec/grover/configuration_spec.rb
+++ b/spec/grover/configuration_spec.rb
@@ -11,4 +11,16 @@ describe Grover::Configuration do
     configuration.options = { foo: 'bar' }
     expect(configuration.options[:foo]).to eq 'bar'
   end
+
+  describe '#meta_tag_prefix' do
+    subject(meta_tag_prefix) { configuration.meta_tag_prefix }
+
+    it { is_expected.to eq 'grover-' }
+
+    context 'when configured differently' do
+      before { configuration.meta_tag_prefix = 'fooPrefix-' }
+
+      it { is_expected.to eq 'fooPrefix-' }
+    end
+  end
 end

--- a/spec/grover/utils_spec.rb
+++ b/spec/grover/utils_spec.rb
@@ -85,6 +85,52 @@ describe Grover::Utils do
     end
   end
 
+  describe '.deep_assign' do
+    subject(:deep_assign) { described_class.deep_assign(hash, keys, value) }
+
+    let(:value) { 'baz' }
+
+    context 'when hash is empty' do
+      let(:hash) { {} }
+      let(:keys) { ['foo'] }
+
+      it do
+        deep_assign
+        expect(hash).to eq('foo' => 'baz')
+      end
+    end
+
+    context 'when hash already contains matching key' do
+      let(:hash) { { 'foo' => 'bar' } }
+      let(:keys) { ['foo'] }
+
+      it do
+        deep_assign
+        expect(hash).to eq('foo' => 'baz')
+      end
+    end
+
+    context 'with multiple keys provided' do
+      let(:hash) { {} }
+      let(:keys) { %w[foo bar] }
+
+      it do
+        deep_assign
+        expect(hash).to eq('foo' => { 'bar' => 'baz' })
+      end
+    end
+
+    context 'with symbol keys' do
+      let(:hash) { {} }
+      let(:keys) { %i[foo bar] }
+
+      it do
+        deep_assign
+        expect(hash).to eq(foo: { bar: 'baz' })
+      end
+    end
+  end
+
   describe '.normalize_object' do
     subject(:normalize_object) { described_class.normalize_object(object) }
 


### PR DESCRIPTION
Using code based on the same feature in PDFKit, allow meta tags to be used to configure the conversion within Puppeteer