### PR TITLE
Fix bugs in handling of meta tag content (inline html templates)

### DIFF
--- a/grover.gemspec
+++ b/grover.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'nokogiri', '~> 1.8.4'
   spec.add_dependency 'schmooze', '~> 0.2'
 
   spec.add_development_dependency 'bundler', '~> 1.3'

--- a/lib/grover.rb
+++ b/lib/grover.rb
@@ -113,9 +113,14 @@ class Grover
     Processor.new(root_path)
   end
 
-  def options_with_template_fix
+  def base_options
     options = @options.dup
     options.merge! meta_options unless url_source?
+    options
+  end
+
+  def options_with_template_fix
+    options = base_options
     display_url = options.delete :display_url
     if display_url
       options[:footer_template] ||= DEFAULT_FOOTER_TEMPLATE
@@ -143,7 +148,7 @@ class Grover
     end
   end
 
-  FALSE_VALUES = [nil, false, 0, '0', 'f', 'F', 'false', 'FALSE', 'off', 'OFF']
+  FALSE_VALUES = [nil, false, 0, '0', 'f', 'F', 'false', 'FALSE', 'off', 'OFF'].freeze
 
   def fix_numeric_options!(options)
     return unless options.key? 'scale'

--- a/lib/grover.rb
+++ b/lib/grover.rb
@@ -143,7 +143,7 @@ class Grover
     end
   end
 
-  FALSE_VALUES = [false, 0, '0', 'f', 'F', 'false', 'FALSE', 'off', 'OFF']
+  FALSE_VALUES = [nil, false, 0, '0', 'f', 'F', 'false', 'FALSE', 'off', 'OFF']
 
   def fix_numeric_options!(options)
     return unless options.key? 'scale'

--- a/lib/grover.rb
+++ b/lib/grover.rb
@@ -161,16 +161,18 @@ class Grover
   def meta_options
     meta_opts = {}
 
-    Nokogiri::HTML(@url).xpath('//meta').each do |meta|
-      next unless meta.key? 'name'
-
-      tag_name = meta['name'][/#{Grover.configuration.meta_tag_prefix}([a-z_-]+)/, 1]
-      next if tag_name.nil?
+    meta_tags.each do |meta|
+      tag_name = meta['name'] && meta['name'][/#{Grover.configuration.meta_tag_prefix}([a-z_-]+)/, 1]
+      next unless tag_name
 
       Utils.deep_assign meta_opts, tag_name.split('-'), meta['content']
     end
 
     meta_opts
+  end
+
+  def meta_tags
+    Nokogiri::HTML(@url).xpath('//meta')
   end
 
   def url_source?

--- a/spec/grover_spec.rb
+++ b/spec/grover_spec.rb
@@ -98,6 +98,60 @@ describe Grover do
         it { expect(pdf_reader.pages.first.attributes).to include(MediaBox: [0, 0, 841.91998, 1188]) }
       end
 
+      context 'when the page contains meta options with escaped content' do
+        let(:options) do
+          {
+            margin: {
+              top: '1in',
+              bottom: '1in'
+            },
+            footer_template: ' '
+          }
+        end
+        let(:url_or_html) do
+          Grover::Utils.squish(<<-HTML)
+            <html>
+              <head>
+                <meta name="grover-header_template" content="#{large_text}Header with &quot;quotes&quot; in it" />
+                <meta name="grover-display_header_footer" content='true' />
+              </head>
+              <body>
+                <h1>Hey there</h1>
+              </body>
+            </html>
+          HTML
+        end
+
+        it { expect(pdf_text_content).to eq 'Header with "quotes" in it Hey there' }
+      end
+
+      context 'when the page contains meta options with boolean content' do
+        let(:options) do
+          {
+            margin: {
+              top: '1in',
+              bottom: '1in'
+            },
+            display_header_footer: true,
+            header_template: 'We dont expect to see this...'
+          }
+        end
+        let(:url_or_html) do
+          Grover::Utils.squish(<<-HTML)
+            <html>
+              <head>
+                <meta name="grover-display_header_footer" content='false' />
+              </head>
+              <body>
+                <h1>Hey there</h1>
+              </body>
+            </html>
+          HTML
+        end
+
+        it { expect(pdf_text_content).to eq 'Hey there' }
+      end
+
       context 'when the page contains invalid meta options' do
         let(:options) { {} }
         let(:url_or_html) do

--- a/spec/grover_spec.rb
+++ b/spec/grover_spec.rb
@@ -113,7 +113,8 @@ describe Grover do
           Grover::Utils.squish(<<-HTML)
             <html>
               <head>
-                <meta name="grover-footer_template" content="Footer with &quot;quotes&quot; in it" />
+                <meta name="grover-footer_template"
+                      content="<div class='text'>Footer with &quot;quotes&quot; in it</div>" />
               </head>
               <body>
                 <h1>Hey there</h1>

--- a/spec/grover_spec.rb
+++ b/spec/grover_spec.rb
@@ -101,19 +101,19 @@ describe Grover do
       context 'when the page contains meta options with escaped content' do
         let(:options) do
           {
+            display_header_footer: true,
             margin: {
               top: '1in',
               bottom: '1in'
             },
-            footer_template: ' '
+            header_template: large_text
           }
         end
         let(:url_or_html) do
           Grover::Utils.squish(<<-HTML)
             <html>
               <head>
-                <meta name="grover-header_template" content="#{large_text}Header with &quot;quotes&quot; in it" />
-                <meta name="grover-display_header_footer" content='true' />
+                <meta name="grover-footer_template" content="Footer with &quot;quotes&quot; in it" />
               </head>
               <body>
                 <h1>Hey there</h1>
@@ -122,7 +122,7 @@ describe Grover do
           HTML
         end
 
-        it { expect(pdf_text_content).to eq 'Header with "quotes" in it Hey there' }
+        it { expect(pdf_text_content).to eq 'Hey there Footer with "quotes" in it' }
       end
 
       context 'when the page contains meta options with boolean content' do


### PR DESCRIPTION
Use nokogiri instead of regexes for parsing out metadata (to deal with embedded HTML header/footer templates)

Fix bug where boolean/numeric type options not handled correctly when passed through meta tags