### PR TITLE
Add support for configuring a front and back cover page for PDFs

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,2 @@
+exclude_patterns:
+  - "lib/active_support_ext/**/*.rb"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,7 @@ RSpec/MessageSpies:
 
 RSpec/NestedGroups:
   Max: 4
+
+Style/Documentation:
+  Exclude:
+    - "lib/active_support_ext/**/*.rb"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Changelog
 
+## Unreleased
+### Added
+- Support for front/back cover pages for middleware (combined with the original request PDF)
+
 ## [0.4.4](releases/tag/v0.4.4) - 2018-09-10
 ### Fixed
 - Bug with options containing mixed symbol/string keys (and how they merge with the parsed meta options)
 
 ## [0.4.3](releases/tag/v0.4.3) - 2018-09-10
 ### Added
-- Pass through flag to indicate to downstream middleware/app that Grover has interacted with the environment 
+- Pass through flag to indicate to upstream middleware/app that Grover has interacted with the environment 
 
 ## [0.4.2](releases/tag/v0.4.2) - 2018-09-09
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -91,17 +91,50 @@ any page on your site by appending .pdf to the URL.
 **Non-Rails Rack apps**
 ```ruby
 # in config.ru
-require 'pdfkit'
+require 'grover'
 use Grover::Middleware
 ```
 
 **Rails apps**
 ```ruby
 # in application.rb
-require 'pdfkit'
+require 'grover'
 config.middleware.use Grover::Middleware
 ```
 
+
+## Cover pages
+Since the header/footer for Puppeteer is configured globally, displaying of front/back cover
+pages (with potentially different headers/footers etc) is not possible.
+
+To get around this, Grover's middleware allows you to specify relative paths for the cover page contents
+via `front_cover_path` and `back_cover_path` either via the global configuration, or via meta tags.
+These paths (with query parameters) are then requested from the upstream app.
+
+The cover pages are converted to PDF in isolation, and then combined together with the original PDF response,
+before being returned back down through the Rack stack. 
+ 
+_N.B_ To simplify things, the same request method and body are used for the cover page requests.
+
+```ruby
+# config/initializers/grover.rb
+Grover.configure do |config|
+  config.options = {
+    front_cover_path: '/some/global/cover/page?foo=bar'
+  }
+end
+```
+
+Or via the meta tags in the original response:
+```HTML
+<html>
+  <head>
+    <meta name="grover-back_cover_path" content="/back/cover/page?bar=baz" />
+  </head>
+  ...
+</html>    
+```
+ 
 
 ## Contributing
 

--- a/grover.gemspec
+++ b/grover.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'combine_pdf', '~> 1.0'
   spec.add_dependency 'nokogiri', '~> 1.0'
   spec.add_dependency 'schmooze', '~> 0.2'
 

--- a/lib/active_support_ext/object/deep_dup.rb
+++ b/lib/active_support_ext/object/deep_dup.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Copied from active support
+# @see active_support/core_ext/object/duplicable.rb
+
+require 'active_support_ext/object/duplicable'
+
+class Object
+  # Returns a deep copy of object if it's duplicable. If it's
+  # not duplicable, returns +self+.
+  #
+  #   object = Object.new
+  #   dup    = object.deep_dup
+  #   dup.instance_variable_set(:@a, 1)
+  #
+  #   object.instance_variable_defined?(:@a) # => false
+  #   dup.instance_variable_defined?(:@a)    # => true
+  def deep_dup
+    duplicable? ? dup : self
+  end
+end
+
+class Array
+  # Returns a deep copy of array.
+  #
+  #   array = [1, [2, 3]]
+  #   dup   = array.deep_dup
+  #   dup[1][2] = 4
+  #
+  #   array[1][2] # => nil
+  #   dup[1][2]   # => 4
+  def deep_dup
+    map(&:deep_dup)
+  end
+end
+
+class Hash
+  # Returns a deep copy of hash.
+  #
+  #   hash = { a: { b: 'b' } }
+  #   dup  = hash.deep_dup
+  #   dup[:a][:c] = 'c'
+  #
+  #   hash[:a][:c] # => nil
+  #   dup[:a][:c]  # => "c"
+  def deep_dup
+    hash = dup
+    each_pair do |key, value|
+      if key.frozen? && key.is_a?(::String)
+        hash[key] = value.deep_dup
+      else
+        hash.delete(key)
+        hash[key.deep_dup] = value.deep_dup
+      end
+    end
+    hash
+  end
+end

--- a/lib/active_support_ext/object/duplicable.rb
+++ b/lib/active_support_ext/object/duplicable.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+# Copied from active support
+# @see active_support/core_ext/object/duplicable.rb
+
+#--
+# Most objects are cloneable, but not all. For example you can't dup methods:
+#
+#   method(:puts).dup # => TypeError: allocator undefined for Method
+#
+# Classes may signal their instances are not duplicable removing +dup+/+clone+
+# or raising exceptions from them. So, to dup an arbitrary object you normally
+# use an optimistic approach and are ready to catch an exception, say:
+#
+#   arbitrary_object.dup rescue object
+#
+# Rails dups objects in a few critical spots where they are not that arbitrary.
+# That rescue is very expensive (like 40 times slower than a predicate), and it
+# is often triggered.
+#
+# That's why we hardcode the following cases and check duplicable? instead of
+# using that rescue idiom.
+#++
+class Object
+  # Can you safely dup this object?
+  #
+  # False for method objects;
+  # true otherwise.
+  def duplicable?
+    true
+  end
+end
+
+class NilClass
+  begin
+    nil.dup
+  rescue TypeError
+    # +nil+ is not duplicable:
+    #
+    #   nil.duplicable? # => false
+    #   nil.dup         # => TypeError: can't dup NilClass
+    def duplicable?
+      false
+    end
+  end
+end
+
+class FalseClass
+  begin
+    false.dup
+  rescue TypeError
+    # +false+ is not duplicable:
+    #
+    #   false.duplicable? # => false
+    #   false.dup         # => TypeError: can't dup FalseClass
+    def duplicable?
+      false
+    end
+  end
+end
+
+class TrueClass
+  begin
+    true.dup
+  rescue TypeError
+    # +true+ is not duplicable:
+    #
+    #   true.duplicable? # => false
+    #   true.dup         # => TypeError: can't dup TrueClass
+    def duplicable?
+      false
+    end
+  end
+end
+
+class Symbol
+  begin
+    :symbol.dup # Ruby 2.4.x.
+    'symbol_from_string'.to_sym.dup # Some symbols can't `dup` in Ruby 2.4.0.
+  rescue TypeError
+    # Symbols are not duplicable:
+    #
+    #   :my_symbol.duplicable? # => false
+    #   :my_symbol.dup         # => TypeError: can't dup Symbol
+    def duplicable?
+      false
+    end
+  end
+end
+
+class Numeric
+  begin
+    1.dup
+  rescue TypeError
+    # Numbers are not duplicable:
+    #
+    #  3.duplicable? # => false
+    #  3.dup         # => TypeError: can't dup Integer
+    def duplicable?
+      false
+    end
+  end
+end
+
+require 'bigdecimal'
+class BigDecimal
+  # BigDecimals are duplicable:
+  #
+  #   BigDecimal("1.2").duplicable? # => true
+  #   BigDecimal("1.2").dup         # => #<BigDecimal:...,'0.12E1',18(18)>
+  def duplicable?
+    true
+  end
+end
+
+class Method
+  # Methods are not duplicable:
+  #
+  #  method(:puts).duplicable? # => false
+  #  method(:puts).dup         # => TypeError: allocator undefined for Method
+  def duplicable?
+    false
+  end
+end
+
+class Complex
+  begin
+    Complex(1).dup
+  rescue TypeError
+    # Complexes are not duplicable:
+    #
+    #   Complex(1).duplicable? # => false
+    #   Complex(1).dup         # => TypeError: can't copy Complex
+    def duplicable?
+      false
+    end
+  end
+end
+
+class Rational
+  begin
+    Rational(1).dup
+  rescue TypeError
+    # Rationals are not duplicable:
+    #
+    #   Rational(1).duplicable? # => false
+    #   Rational(1).dup         # => TypeError: can't copy Rational
+    def duplicable?
+      false
+    end
+  end
+end

--- a/lib/grover/middleware.rb
+++ b/lib/grover/middleware.rb
@@ -47,7 +47,7 @@ class Grover
 
     def convert_to_pdf(response)
       grover = create_grover_for_response(response)
-      if grover.has_front_cover_path? || grover.has_back_cover_path?
+      if grover.show_front_cover? || grover.show_back_cover?
         add_cover_content grover
       else
         grover.to_pdf

--- a/lib/grover/middleware.rb
+++ b/lib/grover/middleware.rb
@@ -1,3 +1,5 @@
+require 'combine_pdf'
+
 class Grover
   #
   # Rack middleware for catching PDF requests and returning the upstream HTML as a PDF
@@ -44,11 +46,36 @@ class Grover
     end
 
     def convert_to_pdf(response)
+      grover = create_grover_for_response(response)
+      if grover.has_front_cover_path? || grover.has_back_cover_path?
+        add_cover_content grover
+      else
+        grover.to_pdf
+      end
+    end
+
+    def create_grover_for_response(response)
       body = response.respond_to?(:body) ? response.body : response.join
       body = body.join if body.is_a?(Array)
 
       body = HTMLPreprocessor.process body, root_url, protocol
-      Grover.new(body, display_url: request_url).to_pdf
+      Grover.new(body, display_url: request_url)
+    end
+
+    def add_cover_content(grover)
+      pdf = CombinePDF.parse grover.to_pdf
+      pdf >> fetch_cover_pdf(grover.front_cover_path) if grover.show_front_cover?
+      pdf << fetch_cover_pdf(grover.back_cover_path) if grover.show_back_cover?
+      pdf.to_pdf
+    end
+
+    def fetch_cover_pdf(url)
+      temp_env = env.deep_dup
+      temp_env['PATH_INFO'], temp_env['QUERY_STRING'] = url.split '?'
+      _, _, response = @app.call(env)
+      response.close if response.respond_to? :close
+      grover = create_grover_for_response response
+      CombinePDF.parse grover.to_pdf
     end
 
     def update_headers(headers, body)

--- a/lib/grover/middleware.rb
+++ b/lib/grover/middleware.rb
@@ -69,10 +69,10 @@ class Grover
       pdf.to_pdf
     end
 
-    def fetch_cover_pdf(url)
+    def fetch_cover_pdf(path)
       temp_env = env.deep_dup
-      temp_env['PATH_INFO'], temp_env['QUERY_STRING'] = url.split '?'
-      _, _, response = @app.call(env)
+      temp_env['PATH_INFO'], temp_env['QUERY_STRING'] = path.split '?'
+      _, _, response = @app.call(temp_env)
       response.close if response.respond_to? :close
       grover = create_grover_for_response response
       CombinePDF.parse grover.to_pdf

--- a/lib/grover/utils.rb
+++ b/lib/grover/utils.rb
@@ -63,6 +63,9 @@ class Grover
       end
     end
 
+    #
+    # Deep transform the keys in the hash to strings
+    #
     def self.deep_stringify_keys(hash)
       deep_transform_keys_in_object hash, &:to_s
     end
@@ -70,15 +73,13 @@ class Grover
     #
     # Deep merge a hash with another hash
     #
-    # Copied from active support
+    # Based on active support
     # @see active_support/core_ext/hash/deep_merge.rb
     #
-    def self.deep_merge!(hash, other_hash, &block)
-      hash.merge!(other_hash) do |key, this_val, other_val|
+    def self.deep_merge!(hash, other_hash)
+      hash.merge!(other_hash) do |_, this_val, other_val|
         if this_val.is_a?(Hash) && other_val.is_a?(Hash)
-          deep_merge!(this_val.dup, other_val, &block)
-        elsif block_given?
-          block.call(key, this_val, other_val)
+          deep_merge! this_val.dup, other_val
         else
           other_val
         end

--- a/spec/grover/middleware_spec.rb
+++ b/spec/grover/middleware_spec.rb
@@ -141,7 +141,7 @@ describe Grover::Middleware do
     end
 
     describe 'pdf conversion' do
-      let(:grover) { instance_double Grover }
+      let(:grover) { instance_double Grover, show_front_cover?: false, show_back_cover?: false }
 
       it 'passes through the request URL (sans extension) to Grover' do
         expect(Grover).to(

--- a/spec/grover/middleware_spec.rb
+++ b/spec/grover/middleware_spec.rb
@@ -169,13 +169,13 @@ describe Grover::Middleware do
             @env = env
             response =
               if env['PATH_INFO'] == '/front/page/meta'
-                "This is the cover page - #{env['QUERY_STRING']}"
+                "This is the cover page with params #{env['QUERY_STRING']}"
               else
                 Grover::Utils.squish(<<-HTML)
                   <html>
                     <head>
                       <title>Paaage</title>
-                      <meta name="grover-front_cover_path" content="/front/page/meta?and-a-query=baz" />
+                      <meta name="grover-front_cover_path" content="/front/page/meta?queryparam=baz" />
                     </head>
                     <body>
                       <h1>Hey there</h1>
@@ -190,7 +190,9 @@ describe Grover::Middleware do
 
         it { expect(pdf_reader.page_count).to eq 2 }
         it do
-          expect(Grover::Utils.squish(pdf_reader.pages[0].text)).to eq 'This is the cover page ­ and­a­query=baz'
+          expect(Grover::Utils.squish(pdf_reader.pages[0].text)).to(
+            eq('This is the cover page with params queryparam=baz')
+          )
         end
         it { expect(Grover::Utils.squish(pdf_reader.pages[1].text)).to eq 'Hey there' }
       end
@@ -201,13 +203,13 @@ describe Grover::Middleware do
             @env = env
             response =
               if env['PATH_INFO'] == '/back/page/meta'
-                "This is the back page - #{env['QUERY_STRING']}"
+                "This is the back page with params #{env['QUERY_STRING']}"
               else
                 Grover::Utils.squish(<<-HTML)
                   <html>
                     <head>
                       <title>Paaage</title>
-                      <meta name="grover-back_cover_path" content="/back/page/meta?another-query=foo" />
+                      <meta name="grover-back_cover_path" content="/back/page/meta?anotherquery=foo" />
                     </head>
                     <body>
                       <h1>Hey there</h1>
@@ -223,7 +225,9 @@ describe Grover::Middleware do
         it { expect(pdf_reader.page_count).to eq 2 }
         it { expect(Grover::Utils.squish(pdf_reader.pages[0].text)).to eq 'Hey there' }
         it do
-          expect(Grover::Utils.squish(pdf_reader.pages[1].text)).to eq 'This is the back page ­ another­query=foo'
+          expect(Grover::Utils.squish(pdf_reader.pages[1].text)).to(
+            eq('This is the back page with params anotherquery=foo')
+          )
         end
       end
     end

--- a/spec/grover/utils_spec.rb
+++ b/spec/grover/utils_spec.rb
@@ -131,6 +131,155 @@ describe Grover::Utils do
     end
   end
 
+  describe '.deep_transform_keys_in_object' do
+    subject(:deep_transform_keys_in_object) do
+      described_class.deep_transform_keys_in_object(hash) { |key| key.to_s.upcase }
+    end
+
+    context 'when hash is empty' do
+      let(:hash) { {} }
+
+      it { is_expected.to eq({}) }
+    end
+
+    context 'when hash has basic keys' do
+      let(:hash) { { foo: 'bar' } }
+
+      it { is_expected.to eq('FOO' => 'bar') }
+
+      it 'doesnt modify the original hash' do
+        deep_transform_keys_in_object
+        expect(hash).to eq(foo: 'bar')
+      end
+    end
+
+    context 'when hash contains an array of hashes' do
+      let(:hash) { { foo: [{ bar: 'baz' }] } }
+
+      it { is_expected.to eq('FOO' => [{ 'BAR' => 'baz' }]) }
+
+      it 'doesnt modify the original hash' do
+        deep_transform_keys_in_object
+        expect(hash).to eq(foo: [{ bar: 'baz' }])
+      end
+    end
+  end
+
+  describe '.deep_stringify_keys' do
+    subject(:deep_stringify_keys) { described_class.deep_stringify_keys(hash) }
+
+    context 'when hash is empty' do
+      let(:hash) { {} }
+
+      it { is_expected.to eq({}) }
+    end
+
+    context 'when hash has keys' do
+      let(:hash) { { foo: 'bar' } }
+
+      it { is_expected.to eq('foo' => 'bar') }
+
+      it 'doesnt modify the original hash' do
+        deep_stringify_keys
+        expect(hash).to eq(foo: 'bar')
+      end
+    end
+  end
+
+  describe '.deep_merge!' do
+    subject(:deep_merge!) { described_class.deep_merge! hash1, hash2 }
+
+    context 'when both hashes are empty' do
+      let(:hash1) { {} }
+      let(:hash2) { {} }
+
+      it { is_expected.to eq({}) }
+      it do
+        deep_merge!
+        expect(hash1).to eq({})
+      end
+      it do
+        deep_merge!
+        expect(hash2).to eq({})
+      end
+    end
+
+    context 'when hash1 has some keys' do
+      let(:hash1) { { foo: 'bar' } }
+      let(:hash2) { {} }
+
+      it { is_expected.to eq(foo: 'bar') }
+      it do
+        deep_merge!
+        expect(hash1).to eq(foo: 'bar')
+      end
+      it do
+        deep_merge!
+        expect(hash2).to eq({})
+      end
+    end
+
+    context 'when hash2 has some keys' do
+      let(:hash1) { {} }
+      let(:hash2) { { foo: 'bar' } }
+
+      it { is_expected.to eq(foo: 'bar') }
+      it do
+        deep_merge!
+        expect(hash1).to eq(foo: 'bar')
+      end
+      it do
+        deep_merge!
+        expect(hash2).to eq(foo: 'bar')
+      end
+    end
+
+    context 'when both hashes have keys (different)' do
+      let(:hash1) { { bar: 'baz' } }
+      let(:hash2) { { foo: 'bar' } }
+
+      it { is_expected.to eq(foo: 'bar', bar: 'baz') }
+      it do
+        deep_merge!
+        expect(hash1).to eq(foo: 'bar', bar: 'baz')
+      end
+      it do
+        deep_merge!
+        expect(hash2).to eq(foo: 'bar')
+      end
+    end
+
+    context 'when both hashes have keys (same)' do
+      let(:hash1) { { foo: 'baz', baz: 'foo' } }
+      let(:hash2) { { foo: 'bar' } }
+
+      it { is_expected.to eq(foo: 'bar', baz: 'foo') }
+      it do
+        deep_merge!
+        expect(hash1).to eq(foo: 'bar', baz: 'foo')
+      end
+      it do
+        deep_merge!
+        expect(hash2).to eq(foo: 'bar')
+      end
+    end
+
+    context 'when both hashes have keys (same/deep)' do
+      let(:hash1) { { foo: { bar: 'baz' }, fizz: 'buzz' } }
+      let(:hash2) { { foo: { baz: 'bar', bar: 'foo' } } }
+
+      it { is_expected.to eq(foo: { bar: 'foo', baz: 'bar' }, fizz: 'buzz') }
+      it do
+        deep_merge!
+        expect(hash1).to eq(foo: { bar: 'foo', baz: 'bar' }, fizz: 'buzz')
+      end
+      it do
+        deep_merge!
+        expect(hash2).to eq(foo: { baz: 'bar', bar: 'foo' })
+      end
+    end
+  end
+
   describe '.normalize_object' do
     subject(:normalize_object) { described_class.normalize_object(object) }
 

--- a/spec/grover_spec.rb
+++ b/spec/grover_spec.rb
@@ -15,14 +15,14 @@ describe Grover do
 
       it { expect(new.instance_variable_get('@url')).to eq 'http://happyfuntimes.com' }
       it { expect(new.instance_variable_get('@root_path')).to be_nil }
-      it { expect(new.instance_variable_get('@options')).to eq(page_size: 'A4') }
+      it { expect(new.instance_variable_get('@options')).to eq('page_size' => 'A4') }
 
       context 'with root path specified' do
         let(:options) { { page_size: 'A4', root_path: 'foo/bar/baz' } }
 
         it { expect(new.instance_variable_get('@url')).to eq 'http://happyfuntimes.com' }
         it { expect(new.instance_variable_get('@root_path')).to eq 'foo/bar/baz' }
-        it { expect(new.instance_variable_get('@options')).to eq(page_size: 'A4') }
+        it { expect(new.instance_variable_get('@options')).to eq('page_size' => 'A4') }
       end
     end
   end

--- a/spec/grover_spec.rb
+++ b/spec/grover_spec.rb
@@ -39,6 +39,16 @@ describe Grover do
     let(:pdf_text_content) { Grover::Utils.squish(pdf_reader.pages.first.text) }
     let(:large_text) { '<style>.text { font-size: 14px; }</style>' }
     let(:default_header) { Grover::DEFAULT_HEADER_TEMPLATE }
+    let(:basic_header_footer_options) do
+      {
+        display_header_footer: true,
+        display_url: 'http://www.example.net/foo/bar',
+        margin: {
+          top: '1in',
+          bottom: '1in'
+        }
+      }
+    end
 
     context 'when passing through a valid URL' do
       let(:url_or_html) { 'https://www.google.com' }
@@ -102,17 +112,7 @@ describe Grover do
       end
 
       context 'when the page contains meta options with escaped content' do
-        let(:options) do
-          {
-            display_header_footer: true,
-            display_url: 'http://www.example.net/bar',
-            margin: {
-              top: '1in',
-              bottom: '1in'
-            },
-            header_template: large_text
-          }
-        end
+        let(:options) { basic_header_footer_options.merge(header_template: large_text) }
         let(:url_or_html) do
           Grover::Utils.squish(<<-HTML)
             <html>
@@ -131,16 +131,7 @@ describe Grover do
       end
 
       context 'when the page contains meta options with boolean content' do
-        let(:options) do
-          {
-            margin: {
-              top: '1in',
-              bottom: '1in'
-            },
-            display_header_footer: true,
-            header_template: 'We dont expect to see this...'
-          }
-        end
+        let(:options) { basic_header_footer_options.merge(header_template: 'We dont expect to see this...') }
         let(:url_or_html) do
           Grover::Utils.squish(<<-HTML)
             <html>
@@ -180,93 +171,57 @@ describe Grover do
       end
 
       context 'when options include header and footer enabled' do
-        let(:options) do
-          {
-            display_header_footer: true,
-            display_url: 'http://www.example.net/bar',
-            margin: {
-              top: '1in',
-              bottom: '1in'
-            },
-            header_template: "#{large_text}#{default_header}"
-          }
-        end
+        let(:options) { basic_header_footer_options.merge(header_template: "#{large_text}#{default_header}") }
 
         it do
           date = Date.today.strftime '%-m/%-d/%Y'
-          expect(pdf_text_content).to eq "#{date} Paaage Hey there http://www.example.net/bar 1/1"
+          expect(pdf_text_content).to eq "#{date} Paaage Hey there http://www.example.net/foo/bar 1/1"
         end
       end
 
       context 'when options override header template' do
         let(:options) do
-          {
-            display_header_footer: true,
-            display_url: 'http://www.examples.net/foo/baz',
-            margin: {
-              top: '1in',
-              bottom: '1in'
-            },
-            header_template: "#{large_text}<div class='text'>Excellente</div>"
-          }
+          basic_header_footer_options.merge(header_template: "#{large_text}<div class='text'>Excellente</div>")
         end
 
-        it { expect(pdf_text_content).to eq 'Excellente Hey there http://www.examples.net/foo/baz 1/1' }
+        it { expect(pdf_text_content).to eq 'Excellente Hey there http://www.example.net/foo/bar 1/1' }
       end
 
       context 'when header template includes the display url marker' do
         let(:options) do
-          {
-            display_header_footer: true,
-            display_url: 'http://www.examples.net/foo/bar',
-            margin: {
-              top: '1in',
-              bottom: '1in'
-            },
+          basic_header_footer_options.merge(
             header_template: "#{large_text}<div class='text'>abc{{display_url}}def</div>"
-          }
+          )
         end
 
         it do
           expect(pdf_text_content).to(
-            eq('abchttp://www.examples.net/foo/bardef Hey there http://www.examples.net/foo/bar 1/1')
+            eq('abchttp://www.example.net/foo/bardef Hey there http://www.example.net/foo/bar 1/1')
           )
         end
       end
 
       context 'when options override footer template' do
         let(:options) do
-          {
-            display_header_footer: true,
-            display_url: 'http://www.examples.net/foo/bar',
-            margin: {
-              top: '1in',
-              bottom: '1in'
-            },
+          basic_header_footer_options.merge(
             footer_template: "#{large_text}<div class='text'>great {{display_url}} page</div>"
-          }
+          )
         end
 
         it do
           date = Date.today.strftime '%-m/%-d/%Y'
-          expect(pdf_text_content).to eq "#{date} Paaage Hey there great http://www.examples.net/foo/bar page"
+          expect(pdf_text_content).to eq "#{date} Paaage Hey there great http://www.example.net/foo/bar page"
         end
       end
     end
 
     context 'when global options are defined' do
       let(:url_or_html) { '<html><body><h1>Hey there</h1></body></html>' }
-      let(:options) do
-        {
-          display_header_footer: true,
-          display_url: 'http://www.examples.net/foo/bar',
-          header_template: large_text
-        }
-      end
+      let(:options) { basic_header_footer_options.merge(header_template: large_text) }
 
       before { allow(described_class.configuration).to receive(:options).and_return(options) }
 
-      it { expect(pdf_text_content).to eq 'Hey there http://www.examples.net/foo/bar 1/1' }
+      it { expect(pdf_text_content).to eq 'Hey there http://www.example.net/foo/bar 1/1' }
     end
 
     context 'when HTML includes screen only content' do


### PR DESCRIPTION
Because Puppeteer doesn't allow for the header/footer to be configured 'per page' on a programatic basis, instead we'll try overcome this by allowing the response PDF to have a specified page (or pages) added to the front and back.

The specified path will be requested via the middleware (to the downstream app) using the same request method/body as the original request, but will override the path/params with those specified in the `front_cover_path` and `back_cover_path` parameters.

These parameters can be configured in the global options or via meta tags in the original downstream response.