### PR TITLE
Use request interception instead of data URL for raw HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
 ## Unreleased
-- None
+### Fixed
+- Use request interception instead of data URL for middleware/raw HTML conversions
+
+### Breaking change
+- The `{{display_url}}` header/footer hack was removed in favour of passing the URL via `display_url` option
+  (for middleware/raw HTML only) 
 
 ## [0.5.5](releases/tag/v0.5.5) - 2018-09-20
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -63,26 +63,22 @@ Grover.configure do |config|
 end
 ```
 
-#### Header/Footer templates and the 'url' tag
-When using the Rack middleware, Grover passes the HTML response through to Puppeteer as inline HTML.
-As such, if the header/footer flag is enabled, by default Chromium will render the url
-(the entire HTML document as plain text) in the footer. Eep!
+#### Page URL for middleware requests (or passing through raw HTML)
+If you want to have the header or footer display the page URL and because this information is not available in the raw
+HTML, Grover requires that this is passed through via the `display_url` option.
 
-To get around this it is recommended to not use the 'url' class in either template.
-Instead, place the text `{{display_url}}` where you would like the request URL to display.
-Grover will look for that text, and replace it with the request URL before converting the HTML to PDF
+For Rack middleware conversions, the original request URL (without the .pdf extension) will be pass assigned to
+`display_url`. You can of course override this by setting using a meta tag in the downstream HTML response.
 
-To assist in this process, if the footer template has not been specified, the following default template is used:
-```HTML
-<div class='text left grow'>{{display_url}}</div>
-<div class='text right'>
-  <span class='pageNumber'></span>/<span class='totalPages'></span>
-</div>    
-```
-_N.B._ the `url` class is *not* used
+For raw HTML conversions, if the `display_url` is not provided `http://example.com` will be used as the default.
 
-I've raised [an issue](https://github.com/GoogleChrome/puppeteer/issues/3133) in the Google Puppeteer project regarding
-a longer term solution to this, however it would need to be resolved upstream in the Chromium project first 
+#### Header and footer templates
+Should be valid HTML markup with following classes used to inject printing values into them:
+* `date` formatted print date
+* `title` document title
+* `url` document location
+* `pageNumber` current page number
+* `totalPages` total pages in the document  
 
 
 ## Middleware

--- a/lib/grover.rb
+++ b/lib/grover.rb
@@ -81,11 +81,9 @@ class Grover
   end
   private_constant :Processor
 
-  DISPLAY_URL_PLACEHOLDER = '{{display_url}}'.freeze
-
   DEFAULT_HEADER_TEMPLATE = "<div class='date text left'></div><div class='title text center'></div>".freeze
   DEFAULT_FOOTER_TEMPLATE = Utils.strip_heredoc(<<-HTML).freeze
-    <div class='text left grow'>#{DISPLAY_URL_PLACEHOLDER}</div>
+    <div class='url text left grow'></div>
     <div class='text right'><span class='pageNumber'></span>/<span class='totalPages'></span></div>
   HTML
 
@@ -174,7 +172,6 @@ class Grover
     Utils.deep_merge! combined, Utils.deep_stringify_keys(options)
     Utils.deep_merge! combined, meta_options unless url_source?
 
-    # fix_templates! combined
     fix_boolean_options! combined
     fix_numeric_options! combined
 
@@ -203,19 +200,6 @@ class Grover
 
   def url_source?
     @url.match(/^http/i)
-  end
-
-  def fix_templates!(options)
-    display_url = options.delete 'display_url'
-    return unless display_url
-
-    options['footer_template'] ||= DEFAULT_FOOTER_TEMPLATE
-
-    %w[header_template footer_template].each do |key|
-      next unless options[key].is_a? ::String
-
-      options[key] = options[key].gsub(DISPLAY_URL_PLACEHOLDER, display_url)
-    end
   end
 
   def fix_boolean_options!(options)

--- a/lib/grover.rb
+++ b/lib/grover.rb
@@ -46,7 +46,7 @@ class Grover
           }
 
           if (url_or_html.match(/^http/i)) {
-            // Request is for a URL, so request it 
+            // Request is for a URL, so request it
             request_options.waitUntil = 'networkidle2';
             await page.goto(url_or_html, request_options);
           } else {

--- a/lib/grover.rb
+++ b/lib/grover.rb
@@ -47,7 +47,15 @@ class Grover
             await page.goto(url, request_options);
           } else {
             request_options.waitUntil = 'networkidle0';
-            await page.goto(`data:text/html,${url}`, request_options);
+            await page.setRequestInterception(true);
+            // Capture first request only
+            page.once('request', request => {
+              // Fulfill request with HTML, and continue all subsequent requests
+              request.respond({ body: url });
+              page.on('request', request => request.continue());
+            });
+            const displayUrl = options.displayUrl; delete options.displayUrl;
+            await page.goto(displayUrl || 'http://example.com', request_options);
           }
 
           const emulateMedia = options.emulateMedia; delete options.emulateMedia;
@@ -159,7 +167,7 @@ class Grover
     Utils.deep_merge! combined, Utils.deep_stringify_keys(options)
     Utils.deep_merge! combined, meta_options unless url_source?
 
-    fix_templates! combined
+    # fix_templates! combined
     fix_boolean_options! combined
     fix_numeric_options! combined
 

--- a/spec/grover_spec.rb
+++ b/spec/grover_spec.rb
@@ -190,7 +190,7 @@ describe Grover do
       context 'when header template includes the display url marker' do
         let(:options) do
           basic_header_footer_options.merge(
-            header_template: "#{large_text}<div class='text'>abc{{display_url}}def</div>"
+            header_template: "#{large_text}<div class='text'>abc<span class='url'></span>def</div>"
           )
         end
 
@@ -204,7 +204,7 @@ describe Grover do
       context 'when options override footer template' do
         let(:options) do
           basic_header_footer_options.merge(
-            footer_template: "#{large_text}<div class='text'>great {{display_url}} page</div>"
+            footer_template: "#{large_text}<div class='text'>great <span class='url'></span> page</div>"
           )
         end
 


### PR DESCRIPTION
Replace data URL injection with request interception for raw HTML conversions (including Rack middleware).

Allows removal of header/footer hack for request URL injection