### PR TITLE
Fix memoization bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## Unreleased
-- None
+### Fixed
+- Removed memoization of path variable in middleware (on occasion a previous requests state was present)
 
 ## [0.6.1](releases/tag/v0.6.1) - 2018-09-20
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ end
 ```
 
 #### Page URL for middleware requests (or passing through raw HTML)
-If you want to have the header or footer display the page URL and because this information is not available in the raw
-HTML, Grover requires that this is passed through via the `display_url` option.
+If you want to have the header or footer display the page URL, Grover requires that this is passed through via the
+`display_url` option. This is because the page URL is not available in the raw HTML!
 
-For Rack middleware conversions, the original request URL (without the .pdf extension) will be pass assigned to
-`display_url`. You can of course override this by setting using a meta tag in the downstream HTML response.
+For Rack middleware conversions, the original request URL (without the .pdf extension) will be passed through and
+assigned to `display_url` for you. You can of course override this by using a meta tag in the downstream HTML response.
 
 For raw HTML conversions, if the `display_url` is not provided `http://example.com` will be used as the default.
 

--- a/lib/grover/configuration.rb
+++ b/lib/grover/configuration.rb
@@ -6,9 +6,7 @@ class Grover
     attr_accessor :options, :meta_tag_prefix
 
     def initialize
-      @options = {
-        cache: false
-      }
+      @options = {}
       @meta_tag_prefix = 'grover-'
     end
   end

--- a/lib/grover/middleware.rb
+++ b/lib/grover/middleware.rb
@@ -15,9 +15,9 @@ class Grover
 
     def call(env)
       @request = Rack::Request.new(env)
-      @render_pdf = false
+      @render_pdf = pdf_request?
 
-      configure_env_for_pdf_request(env) if render_as_pdf?
+      configure_env_for_pdf_request(env) if rendering_pdf?
       status, headers, response = @app.call(env)
 
       if rendering_pdf? && html_content?(headers)
@@ -37,7 +37,7 @@ class Grover
       @render_pdf
     end
 
-    def render_as_pdf?
+    def pdf_request?
       !@request.path.match(PDF_REGEX).nil?
     end
 
@@ -59,7 +59,7 @@ class Grover
       body = body.join if body.is_a?(Array)
 
       body = HTMLPreprocessor.process body, root_url, protocol
-      Grover.new(body, display_url: request_url, cache: false)
+      Grover.new(body, display_url: request_url)
     end
 
     def add_cover_content(grover)
@@ -88,10 +88,7 @@ class Grover
     end
 
     def configure_env_for_pdf_request(env)
-      @render_pdf = true
-
-      env['PATH_INFO'] = path_without_extension
-      env['REQUEST_URI'] = path_without_extension
+      env['PATH_INFO'] = env['REQUEST_URI'] = path_without_extension
       env['HTTP_ACCEPT'] = concat(env['HTTP_ACCEPT'], Rack::Mime.mime_type('.html'))
       env['Rack-Middleware-Grover'] = 'true'
     end
@@ -109,10 +106,7 @@ class Grover
     end
 
     def path_without_extension
-      return @path_without_extension if defined? @path_without_extension
-
-      path = @request.path.sub(PDF_REGEX, '')
-      @path_without_extension = path.sub(@request.script_name, '')
+      @request.path.sub(PDF_REGEX, '').sub(@request.script_name, '')
     end
 
     def request_url

--- a/spec/grover/configuration_spec.rb
+++ b/spec/grover/configuration_spec.rb
@@ -4,7 +4,7 @@ describe Grover::Configuration do
   subject(:configuration) { described_class.new }
 
   it 'sets default for options' do
-    expect(configuration.options).to eq(cache: false)
+    expect(configuration.options).to eq({})
   end
 
   it 'allows other options to be assigned' do

--- a/spec/grover/middleware_spec.rb
+++ b/spec/grover/middleware_spec.rb
@@ -148,7 +148,7 @@ describe Grover::Middleware do
       it 'passes through the request URL (sans extension) to Grover' do
         expect(Grover).to(
           receive(:new).
-            with('Grover McGroveryface', display_url: 'http://www.example.org/test', cache: false).
+            with('Grover McGroveryface', display_url: 'http://www.example.org/test').
             and_return(grover)
         )
         expect(grover).to receive(:to_pdf).with(no_args).and_return 'A converted PDF'

--- a/spec/grover_spec.rb
+++ b/spec/grover_spec.rb
@@ -10,7 +10,7 @@ describe Grover do
 
     it { expect(new.instance_variable_get('@url')).to eq 'http://google.com' }
     it { expect(new.instance_variable_get('@root_path')).to be_nil }
-    it { expect(new.instance_variable_get('@options')).to eq('cache' => false) }
+    it { expect(new.instance_variable_get('@options')).to eq({}) }
 
     context 'with options passed' do
       subject(:new) { described_class.new('http://happyfuntimes.com', options) }
@@ -19,14 +19,14 @@ describe Grover do
 
       it { expect(new.instance_variable_get('@url')).to eq 'http://happyfuntimes.com' }
       it { expect(new.instance_variable_get('@root_path')).to be_nil }
-      it { expect(new.instance_variable_get('@options')).to eq('page_size' => 'A4', 'cache' => false) }
+      it { expect(new.instance_variable_get('@options')).to eq('page_size' => 'A4') }
 
       context 'with root path specified' do
         let(:options) { { page_size: 'A4', root_path: 'foo/bar/baz' } }
 
         it { expect(new.instance_variable_get('@url')).to eq 'http://happyfuntimes.com' }
         it { expect(new.instance_variable_get('@root_path')).to eq 'foo/bar/baz' }
-        it { expect(new.instance_variable_get('@options')).to eq('page_size' => 'A4', 'cache' => false) }
+        it { expect(new.instance_variable_get('@options')).to eq('page_size' => 'A4') }
       end
     end
   end


### PR DESCRIPTION
It looks like Rails speeds things up by re-using the rack objects and just sanitises them between requests. As such, we can't use any memoization (or we end up potentially using data from previous requests). Ouch!