### PR TITLE
Fix bug in meta-option parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## Unreleased
-- None
+### Fixed
+- Metadata options not included if source contained *any* line starting with `http` 
 
 ## [0.7.1](releases/tag/v0.7.1) - 2019-01-22
 ### Added

--- a/lib/grover.rb
+++ b/lib/grover.rb
@@ -212,7 +212,7 @@ class Grover
   end
 
   def url_source?
-    @url.match(/^http/i)
+    @url.match(/\Ahttp/i)
   end
 
   def fix_boolean_options!(options)

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   },
   "homepage": "https://github.com/Studiosity/grover#readme",
   "devDependencies": {
-    "puppeteer": "^1.13.0"
+    "puppeteer": "^1.16.0"
   }
 }

--- a/spec/grover_spec.rb
+++ b/spec/grover_spec.rb
@@ -130,6 +130,25 @@ describe Grover do
         it { expect(pdf_text_content).to eq 'Hey there Footer with "quotes" in it' }
       end
 
+      context 'when the page contains a line starting with `http`' do
+        let(:options) { basic_header_footer_options.merge(header_template: large_text) }
+        let(:url_or_html) do
+          Grover::Utils.strip_heredoc(<<-HTML)
+            <html>
+              <head>
+                <meta name="grover-footer_template" content="<div class='text'>Footer content</div>" />
+              </head>
+              <body>
+                <h1>Hey there</h1>
+            http://example.com
+              </body>
+            </html>
+          HTML
+        end
+
+        it { expect(pdf_text_content).to eq 'Hey there http://example.com Footer content' }
+      end
+
       context 'when the page contains meta options with boolean content' do
         let(:options) { basic_header_footer_options.merge(header_template: 'We dont expect to see this...') }
         let(:url_or_html) do


### PR DESCRIPTION
If HTML content passed through contains any line starting with `http` the option parser was incorrectly identifying the source as a URL and thus not including those options

Update puppeteer development dependency to 1.16.0