### PR TITLE
Add sample code to render a Rails view as PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ N.B.
 * options are underscore case, and sub-options separated with a dash
 * all options can be overwritten, including `emulate_media` and `display_url`
 
+### From a view template
+
+It's easy to render a normal Rails view template as a PDF, using Rails' [`render_to_string`](https://api.rubyonrails.org/classes/AbstractController/Rendering.html#method-i-render_to_string):
+
+```ruby
+html = MyController.new.render_to_string({
+  template: 'controller/view',
+  layout: 'my_layout',
+  locals: { :@instance_var => ... }
+})
+pdf = Grover.new(html, grover_options).to_pdf
+```
+
 ### Relative paths
 If calling Grover directly (not through middleware) you will need to either specify a `display_url` or modify your
 HTML by converting any relative paths to absolute paths before passing to Grover.
@@ -121,19 +134,6 @@ use Grover::Middleware
 # in application.rb
 require 'grover'
 config.middleware.use Grover::Middleware
-```
-
-## PDFs from a view temmplate
-
-It's easy to render a normal Rails view template as a PDF, using Rails' [`render_to_string`](https://api.rubyonrails.org/classes/AbstractController/Rendering.html#method-i-render_to_string):
-
-```ruby
-html = MyController.new.render_to_string({
-  template: 'controller/view',
-  layout: 'my_layout',
-  locals: { :@instance_var => ... }
-})
-pdf = Grover.new(html, grover_options).to_pdf
 ```
 
 ## Cover pages

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ config.middleware.use Grover::Middleware
 
 It's easy to render a normal Rails view template as a PDF, using Rails' [`render_to_string`](https://api.rubyonrails.org/classes/AbstractController/Rendering.html#method-i-render_to_string):
 
-```
+```ruby
 html = MyController.new.render_to_string({
   template: 'controller/view',
   layout: 'my_layout',

--- a/README.md
+++ b/README.md
@@ -123,6 +123,18 @@ require 'grover'
 config.middleware.use Grover::Middleware
 ```
 
+## PDFs from a view temmplate
+
+It's easy to render a normal Rails view template as a PDF, using Rails' [`render_to_string`](https://api.rubyonrails.org/classes/AbstractController/Rendering.html#method-i-render_to_string):
+
+```
+html = MyController.new.render_to_string({
+  template: 'controller/view',
+  layout: 'my_layout',
+  locals: { :@instance_var => ... }
+})
+pdf = Grover.new(html, grover_options).to_pdf
+```
 
 ## Cover pages
 Since the header/footer for Puppeteer is configured globally, displaying of front/back cover


### PR DESCRIPTION
Not sure if this is the right place to include these docs, or even if this should maybe be a method that's inserted into all Controllers (maybe through the middleware)?

I was experimenting with `wicked_pdf`, and it's pretty easy with that project to render a PDF of _any_ Rails view. This code does the same thing with Grover, it could be useful for others?