### PR TITLE
Add fix for weird page width difference between platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ N.B.
 * all options can be overwritten, including `emulate_media` and `display_url`
 
 ### From a view template
-
 It's easy to render a normal Rails view template as a PDF, using Rails' [`render_to_string`](https://api.rubyonrails.org/classes/AbstractController/Rendering.html#method-i-render_to_string):
 
 ```ruby

--- a/spec/grover_spec.rb
+++ b/spec/grover_spec.rb
@@ -113,7 +113,12 @@ describe Grover do
           HTML
         end
 
-        it { expect(pdf_reader.pages.first.attributes).to include(MediaBox: [0, 0, 841.91998, 1188]) }
+        # For some reason, the Mac platform results in a weird page height (not double the A4 width)
+        if /darwin/ =~ RUBY_PLATFORM
+          it { expect(pdf_reader.pages.first.attributes).to include(MediaBox: [0, 0, 841.91998, 1188]) }
+        else
+          it { expect(pdf_reader.pages.first.attributes).to include(MediaBox: [0, 0, 841.91998, 1189.91992]) }
+        end
       end
 
       context 'when the page contains meta options with escaped content' do


### PR DESCRIPTION
For reasons unknown, Travis (linux) and Mac ruby platforms return different results for A3 page height. 

Change handles this by running a different spec depending on the platform