### PR TITLE
Drop support for Ruby 2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## Unreleased
-- None
+### Breaking change
+- Drop support for Ruby 2.2
 
 ## [0.7.4](releases/tag/v0.7.4) - 2019-07-09
 ### Breaking change

--- a/lib/grover.rb
+++ b/lib/grover.rb
@@ -26,7 +26,7 @@ class Grover
       ENV['GROVER_NO_SANDBOX'] == 'true' ? "{args: ['--no-sandbox', '--disable-setuid-sandbox']}" : '{}'
     end
 
-    method :convert_pdf, Utils.strip_heredoc(<<-FUNCTION)
+    method :convert_pdf, <<~FUNCTION
       async (url_or_html, options) => {
         let browser;
         try {
@@ -95,7 +95,7 @@ class Grover
   private_constant :Processor
 
   DEFAULT_HEADER_TEMPLATE = "<div class='date text left'></div><div class='title text center'></div>"
-  DEFAULT_FOOTER_TEMPLATE = Utils.strip_heredoc(<<-HTML).freeze
+  DEFAULT_FOOTER_TEMPLATE = <<~HTML.freeze
     <div class='url text left grow'></div>
     <div class='text right'><span class='pageNumber'></span>/<span class='totalPages'></span></div>
   HTML

--- a/lib/grover.rb
+++ b/lib/grover.rb
@@ -95,7 +95,7 @@ class Grover
   private_constant :Processor
 
   DEFAULT_HEADER_TEMPLATE = "<div class='date text left'></div><div class='title text center'></div>"
-  DEFAULT_FOOTER_TEMPLATE = <<~HTML.freeze
+  DEFAULT_FOOTER_TEMPLATE = <<~HTML
     <div class='url text left grow'></div>
     <div class='text right'><span class='pageNumber'></span>/<span class='totalPages'></span></div>
   HTML

--- a/lib/grover/utils.rb
+++ b/lib/grover/utils.rb
@@ -23,17 +23,6 @@ class Grover
     end
 
     #
-    # Remove minimum spaces from the front of all lines within a string
-    #
-    # Based on active support
-    # @see active_support/core_ext/string/strip.rb
-    #
-    def self.strip_heredoc(string, inline: false)
-      string = string.gsub(/^#{string.scan(/^[ \t]*(?=\S)/).min}/, '')
-      inline ? string.delete("\n") : string
-    end
-
-    #
     # Assign value to a hash using an array of keys to traverse
     #
     def self.deep_assign(hash, keys, value)

--- a/spec/grover/html_preprocessor_spec.rb
+++ b/spec/grover/html_preprocessor_spec.rb
@@ -23,7 +23,7 @@ describe Grover::HTMLPreprocessor do
 
     context 'with host-relative URL with single quotes' do
       let(:html) do
-        Grover::Utils.strip_heredoc <<-HTML
+        <<~HTML
           <html>
             <head>
               <link href='/stylesheets/application.css' rel='stylesheet' type='text/css' />
@@ -36,7 +36,7 @@ describe Grover::HTMLPreprocessor do
       end
 
       it do
-        expect(process).to eq Grover::Utils.strip_heredoc(<<-HTML)
+        expect(process).to eq <<~HTML
           <html>
             <head>
               <link href='http://example.com/stylesheets/application.css' rel='stylesheet' type='text/css' />
@@ -53,7 +53,7 @@ describe Grover::HTMLPreprocessor do
       let(:html) { '<link href="/stylesheets/application.css" media="screen" rel="stylesheet" type="text/css" />' }
 
       it do
-        expect(process).to eq Grover::Utils.strip_heredoc(<<-HTML, inline: true)
+        expect(process).to eq <<~HTML.delete("\n")
           <link href="http://example.com/stylesheets/application.css" media="screen" rel="stylesheet" type="text/css" />
         HTML
       end
@@ -65,7 +65,7 @@ describe Grover::HTMLPreprocessor do
       end
 
       it do
-        expect(process).to eq Grover::Utils.strip_heredoc(<<-HTML, inline: true)
+        expect(process).to eq <<~HTML.delete("\n")
           <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,600' rel='stylesheet' type='text/css'>
         HTML
       end
@@ -77,7 +77,7 @@ describe Grover::HTMLPreprocessor do
       end
 
       it do
-        expect(process).to eq Grover::Utils.strip_heredoc(<<-HTML, inline: true)
+        expect(process).to eq <<~HTML.delete("\n")
           <link href="http://fonts.googleapis.com/css?family=Open+Sans:400,600" rel="stylesheet" type="text/css">
         HTML
       end
@@ -91,7 +91,7 @@ describe Grover::HTMLPreprocessor do
 
     context 'when options not set' do
       let(:html) do
-        Grover::Utils.strip_heredoc <<-HTML
+        <<~HTML
           <link href='//fonts.googleapis.com/css?family=Open+Sans:400,600' rel='stylesheet' type='text/css'>
           <a href='/'><img src='/logo.jpg'></a>
         HTML
@@ -101,7 +101,7 @@ describe Grover::HTMLPreprocessor do
         let(:root_url) { nil }
 
         it do
-          expect(process).to eq Grover::Utils.strip_heredoc(<<-HTML)
+          expect(process).to eq <<~HTML
             <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,600' rel='stylesheet' type='text/css'>
             <a href='/'><img src='/logo.jpg'></a>
           HTML
@@ -112,7 +112,7 @@ describe Grover::HTMLPreprocessor do
         let(:protocol) { nil }
 
         it do
-          expect(process).to eq Grover::Utils.strip_heredoc(<<-HTML)
+          expect(process).to eq <<~HTML
             <link href='//fonts.googleapis.com/css?family=Open+Sans:400,600' rel='stylesheet' type='text/css'>
             <a href='http://example.com/'><img src='http://example.com/logo.jpg'></a>
           HTML

--- a/spec/grover/utils_spec.rb
+++ b/spec/grover/utils_spec.rb
@@ -43,50 +43,6 @@ describe Grover::Utils do
     end
   end
 
-  describe '.strip_heredoc' do
-    subject(:strip_heredoc) { described_class.strip_heredoc string }
-
-    context 'with an empty string' do
-      let(:string) { '' }
-
-      it { is_expected.to eq '' }
-    end
-
-    context 'with a multi-line string and no padding' do
-      let(:string) { "Hey there\nbuddy\n" }
-
-      it { is_expected.to eq string }
-    end
-
-    context 'with a multi-line string and equal space padding' do
-      let(:string) { "    Hey there\n    buddy\n" }
-
-      it { is_expected.to eq "Hey there\nbuddy\n" }
-    end
-
-    context 'with a multi-line string where first line has shorter space padding' do
-      let(:string) { "  Hey there\n   buddy" }
-
-      it { is_expected.to eq "Hey there\n buddy" }
-    end
-
-    context 'with a multi-line string where second line has shorter space padding' do
-      let(:string) { "  Hey there\n buddy" }
-
-      it { is_expected.to eq " Hey there\nbuddy" }
-    end
-
-    context 'when the optional `inline` flag is set to true' do
-      subject(:strip_heredoc) { described_class.strip_heredoc string, inline: true }
-
-      context 'with a multi-line string' do
-        let(:string) { "  Hey there\n   buddy\n" }
-
-        it { is_expected.to eq 'Hey there buddy' }
-      end
-    end
-  end
-
   describe '.deep_assign' do
     subject(:deep_assign) { described_class.deep_assign(hash, keys, value) }
 

--- a/spec/grover_spec.rb
+++ b/spec/grover_spec.rb
@@ -143,7 +143,7 @@ describe Grover do
       context 'when the page contains a line starting with `http`' do
         let(:options) { basic_header_footer_options.merge(header_template: large_text) }
         let(:url_or_html) do
-          Grover::Utils.strip_heredoc(<<-HTML)
+          <<~HTML
             <html>
               <head>
                 <meta name="grover-footer_template" content="<div class='text'>Footer content</div>" />


### PR DESCRIPTION
With Ruby 2.2 EOL in 2018, time to drop support. For Grover that just means we can use the squiggly heredoc 