### PR TITLE
Add support for capturing PNG/JPEG screenshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 ### Breaking change
-- Drop support for Ruby 2.2
+- [#23](https://github.com/Studiosity/grover/pull/23) Drop support for Ruby 2.2
+
+### Added
+- [#25](https://github.com/Studiosity/grover/pull/25) Add support for capturing PNG/JPEG screenshots
 
 ## [0.7.4](releases/tag/v0.7.4) - 2019-07-09
 ### Breaking change

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # Grover
 
-A Ruby gem to transform HTML into PDFs using [Google Puppeteer](https://github.com/GoogleChrome/puppeteer)
+A Ruby gem to transform HTML into PDFs, PNGs or JPEGs using [Google Puppeteer](https://github.com/GoogleChrome/puppeteer)
 and [Chromium](https://www.chromium.org/Home).
 
 ![Grover](/Grover.jpg "Grover")
@@ -31,6 +31,10 @@ grover = Grover.new('https://google.com', format: 'A4')
 
 # Get an inline PDF
 pdf = grover.to_pdf
+
+# Get a screenshot
+png = grover.to_png
+jpeg = grover.to_jpeg 
 
 # Options can be provided through meta tags
 Grover.new('<html><head><meta name="grover-page_ranges" content="1-3"')
@@ -76,8 +80,9 @@ page content and devtools.
 
 
 ## Configuration
-Grover can be configured to adjust the layout of the resulting PDF.
-For available options, see https://github.com/GoogleChrome/puppeteer/blob/v1.7.0/docs/api.md#pagepdfoptions
+Grover can be configured to adjust the layout of the resulting PDF/image.
+
+For available PDF options, see https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagepdfoptions
 
 Also available are the `emulate_media`, `cache` and `timeout` options.
 
@@ -97,6 +102,11 @@ Grover.configure do |config|
   }
 end
 ```
+
+For available PNG/JPEG options, see https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagescreenshotoptions
+
+Note that by default the `full_page` option is set to false and you will get a 800x600 image. You can either specify
+the image size using the `clip` options, or capture the entire page with `full_page` set to `true`. 
 
 #### Page URL for middleware requests (or passing through raw HTML)
 If you want to have the header or footer display the page URL, Grover requires that this is passed through via the

--- a/grover.gemspec
+++ b/grover.gemspec
@@ -10,8 +10,10 @@ Gem::Specification.new do |spec|
   spec.version     = Grover::VERSION
   spec.authors     = ['Andrew Bromwich']
   spec.email       = %w[abromwich@studiosity.com]
-  spec.description = 'Transform HTML into PDFs using Google Puppeteer/Chromium'
-  spec.summary     = 'A Ruby gem to transform HTML into PDFs wrapper the NodeJS Google Puppeteer driver for Chromium'
+  spec.description = 'Transform HTML into PDF/PNG/JPEG using Google Puppeteer/Chromium'
+  spec.summary     = <<~SUMMARY.delete("\n")
+    A Ruby gem to transform HTML into PDF, PNG or JPEG by wrapping the NodeJS Google Puppeteer driver for Chromium
+  SUMMARY
   spec.homepage    = 'http://github.com/Studiosity/grover'
   spec.license     = 'MIT'
 
@@ -24,11 +26,12 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'nokogiri', '~> 1.0'
   spec.add_dependency 'schmooze', '~> 0.2'
 
-  spec.add_development_dependency 'pdf-reader', '~> 2.1'
+  spec.add_development_dependency 'mini_magick', '~> 4.9'
+  spec.add_development_dependency 'pdf-reader', '~> 2.2'
   spec.add_development_dependency 'rack-test', '~> 1.1'
   spec.add_development_dependency 'rake', '~> 12.3'
-  spec.add_development_dependency 'rspec', '~> 3.7'
-  spec.add_development_dependency 'rubocop', '~> 0.53'
-  spec.add_development_dependency 'rubocop-rspec', '~> 1.28'
-  spec.add_development_dependency 'simplecov', '~> 0.15'
+  spec.add_development_dependency 'rspec', '~> 3.8'
+  spec.add_development_dependency 'rubocop', '~> 0.72'
+  spec.add_development_dependency 'rubocop-rspec', '~> 1.33'
+  spec.add_development_dependency 'simplecov', '~> 0.17'
 end

--- a/spec/grover_spec.rb
+++ b/spec/grover_spec.rb
@@ -54,7 +54,7 @@ describe Grover do
 
     context 'when passing through a valid URL' do
       # we need to add the language for test stability
-      # if not added explicitely, google can respond with a different locale
+      # if not added explicitly, google can respond with a different locale
       # based on IP address geo-lookup, timezone, etc.
       let(:url_or_html) { 'https://www.google.com/?gl=us' }
 
@@ -82,8 +82,6 @@ describe Grover do
     end
 
     context 'when passing through options to Grover' do
-      subject(:to_pdf) { grover.to_pdf }
-
       let(:url_or_html) { '<html><head><title>Paaage</title></head><body><h1>Hey there</h1></body></html>' }
 
       context 'when options includes A4 page format' do
@@ -290,6 +288,98 @@ describe Grover do
       end
     end
   end
+
+  # rubocop:disable RSpec/MultipleExpectations
+  describe '#screenshot' do
+    subject(:screenshot) { grover.screenshot }
+
+    let(:image) { MiniMagick::Image.read screenshot }
+
+    context 'when passing through a valid URL' do
+      let(:url_or_html) { 'https://www.google.com/?gl=us' }
+
+      # default screenshot is PNG 800w x 600h
+      it { expect(screenshot.unpack('C*')).to start_with "\x89PNG\r\n\x1A\n".unpack('C*') }
+      it { expect(image.type).to eq 'PNG' }
+      it { expect(image.dimensions).to eq [800, 600] }
+
+      # don't really want to rely on pixel testing the website screenshot
+      # so we'll check it's mean colour and kurtosis are roughly what we expect
+      it 'contains approximations of colour and frequency distribution sharpness' do
+        expect(image.data.dig('imageStatistics', 'all', 'mean').to_f).to be_within(0.5).of 188.4
+        expect(image.data.dig('imageStatistics', 'all', 'kurtosis').to_f).to be_within(50).of 3625.3
+      end
+    end
+
+    context 'when passing through html' do
+      let(:url_or_html) { '<html><body style="background-color: blue"></body></html>' }
+
+      it { expect(screenshot.unpack('C*')).to start_with "\x89PNG\r\n\x1A\n".unpack('C*') }
+      it { expect(image.type).to eq 'PNG' }
+      it { expect(image.dimensions).to eq [800, 600] }
+
+      it 'contains only blue' do
+        expect(image.data.dig('channelStatistics', 'red', 'mean')).to eq '0'
+        expect(image.data.dig('channelStatistics', 'green', 'mean')).to eq '0'
+        expect(image.data.dig('channelStatistics', 'blue', 'mean')).to eq '255'
+        expect(image.data.dig('channelStatistics', 'alpha', 'mean')).to eq '255'
+      end
+    end
+
+    context 'when passing through options to Grover' do
+      let(:url_or_html) { '<html><body style="background-color: red"></body></html>' }
+      let(:options) { { clip: { x: 0, y: 0, width: 200, height: 100 } } }
+
+      it { expect(screenshot.unpack('C*')).to start_with "\x89PNG\r\n\x1A\n".unpack('C*') }
+      it { expect(image.type).to eq 'PNG' }
+      it { expect(image.dimensions).to eq [200, 100] }
+
+      it 'contains only red' do
+        expect(image.data.dig('channelStatistics', 'red', 'mean')).to eq '255'
+        expect(image.data.dig('channelStatistics', 'green', 'mean')).to eq '0'
+        expect(image.data.dig('channelStatistics', 'blue', 'mean')).to eq '0'
+        expect(image.data.dig('channelStatistics', 'alpha', 'mean')).to eq '255'
+      end
+    end
+  end
+
+  describe '#to_png' do
+    subject(:to_png) { grover.to_png }
+
+    let(:image) { MiniMagick::Image.read to_png }
+    let(:url_or_html) { '<html><body style="background-color: green"></body></html>' }
+
+    it { expect(to_png.unpack('C*')).to start_with "\x89PNG\r\n\x1A\n".unpack('C*') }
+    it { expect(image.type).to eq 'PNG' }
+    it { expect(image.dimensions).to eq [800, 600] }
+
+    it 'contains only green' do
+      expect(image.data.dig('channelStatistics', 'red', 'mean')).to eq '0'
+      expect(image.data.dig('channelStatistics', 'green', 'mean')).to eq '128'
+      expect(image.data.dig('channelStatistics', 'blue', 'mean')).to eq '0'
+      expect(image.data.dig('channelStatistics', 'alpha', 'mean')).to eq '255'
+    end
+  end
+
+  describe '#to_jpeg' do
+    subject(:to_jpeg) { grover.to_jpeg }
+
+    let(:image) { MiniMagick::Image.read to_jpeg }
+    let(:url_or_html) { '<html><body style="background-color: purple"></body></html>' }
+
+    it { expect(to_jpeg.unpack('C*')).to start_with [0xFF, 0xD8, 0xFF] }
+    it { expect(to_jpeg[6..9]).to eq 'JFIF' }
+    it { expect(to_jpeg.unpack('C*')).to end_with [0xFF, 0xD9] }
+    it { expect(image.type).to eq 'JPEG' }
+    it { expect(image.dimensions).to eq [800, 600] }
+
+    it 'contains only purple' do
+      expect(image.data.dig('channelStatistics', 'red', 'mean')).to eq '129'
+      expect(image.data.dig('channelStatistics', 'green', 'mean')).to eq '0'
+      expect(image.data.dig('channelStatistics', 'blue', 'mean')).to eq '127'
+    end
+  end
+  # rubocop:enable RSpec/MultipleExpectations
 
   describe '#front_cover_path' do
     subject(:front_cover_path) { grover.front_cover_path }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,9 +9,12 @@ require 'grover'
 require 'rack/test'
 require 'stringio'
 require 'pdf-reader'
+require 'mini_magick'
 
 RSpec.configure do |config|
   config.order = 'random'
 
   include Rack::Test::Methods
 end
+
+MiniMagick.validate_on_create = false


### PR DESCRIPTION
Doesn't include middleware changes, for now just adding a way to call to the puppeteer `screenshot` method: https://github.com/GoogleChrome/puppeteer/blob/v1.18.1/docs/api.md#pagescreenshotoptions

Helper methods `to_png` and `to_jpeg` are also included