### PR TITLE
Add PNG/JPEG conversion middleware

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,13 +14,13 @@ Metrics/LineLength:
   Max: 120
 
 RSpec/ExampleLength:
-  Max: 10
+  Max: 12
 
 RSpec/MessageSpies:
   EnforcedStyle: receive
 
 RSpec/NestedGroups:
-  Max: 4
+  Max: 5
 
 Style/Documentation:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,9 @@ Metrics/BlockLength:
   Exclude:
     - "**/*_spec.rb"
 
+Metrics/ClassLength:
+  Max: 125
+
 Metrics/LineLength:
   Max: 120
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Added
 - [#25](https://github.com/Studiosity/grover/pull/25) Add support for capturing PNG/JPEG screenshots
-- Add support for PNG/JPEG middleware requests
+- [#27](https://github.com/Studiosity/grover/pull/27) Add support for PNG/JPEG middleware requests
 
 ## [0.7.4](releases/tag/v0.7.4) - 2019-07-09
 ### Breaking change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 - [#25](https://github.com/Studiosity/grover/pull/25) Add support for capturing PNG/JPEG screenshots
+- Add support for PNG/JPEG middleware requests
 
 ## [0.7.4](releases/tag/v0.7.4) - 2019-07-09
 ### Breaking change

--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ Should be valid HTML markup with following classes used to inject printing value
 
 
 ## Middleware
-Grover comes with a middleware that allows users to get a PDF view of
-any page on your site by appending .pdf to the URL.
+Grover comes with a middleware that allows users to get a PDF, PNG or JPEG view of
+any page on your site by appending .pdf, .png or .jpeg/.jpg to the URL.
 
 ### Middleware Setup
 **Non-Rails Rack apps**
@@ -143,6 +143,48 @@ use Grover::Middleware
 # in application.rb
 require 'grover'
 config.middleware.use Grover::Middleware
+```
+
+N.B. by default PNG and JPEG are not modified in the middleware to prevent breaking standard behaviours.
+To enable them, there are configuration options for each image type as well as an option to disable the PDF middleware
+(on by default).
+
+If either of the image handling middleware options are enabled, the [ignore_path](#ignore_path) should also
+be configured, otherwise assets are likely to be handled which would likely result in 404 responses.  
+
+```ruby
+# config/initializers/grover.rb
+Grover.configure do |config|
+  config.use_png_middleware = true
+  config.use_jpeg_middleware = true
+  config.use_pdf_middleware = false
+end
+```
+
+#### ignore_path
+The `ignore_path` configuration option can be used to tell Grover's middleware whether it should handle/modify
+the response. There are three ways to set up the `ignore_path`:
+ * a `String` which matches the start of the request path.
+ * a `Regexp` which could match any part of the request path.
+ * a `Proc` which accepts the request path as a parameter.
+
+```ruby
+# config/initializers/grover.rb
+Grover.configure do |config|
+  # assigning a String
+  config.ignore_path = '/assets/'
+  # matches `www.example.com/assets/foo.png` and not `www.example.com/bar/assets/foo.png`
+
+  # assigning a Regexp
+  config.ignore_path = /my\/path/
+  # matches `www.example.com/foo/my/path/bar.png` 
+
+  # assigning a Proc
+  config.ignore_path = ->(path) do
+    /\A\/foo\/.+\/[0-9]+\.png\z/.match path 
+  end
+  # matches `www.example.com/foo/bar/123.png`
+end
 ```
 
 ## Cover pages

--- a/lib/grover/configuration.rb
+++ b/lib/grover/configuration.rb
@@ -5,11 +5,13 @@ class Grover
   # Configuration of the options for Grover HTML to PDF conversion
   #
   class Configuration
-    attr_accessor :options, :meta_tag_prefix, :use_pdf_middleware, :use_png_middleware, :use_jpeg_middleware
+    attr_accessor :options, :meta_tag_prefix, :ignore_path,
+                  :use_pdf_middleware, :use_png_middleware, :use_jpeg_middleware
 
     def initialize
       @options = {}
       @meta_tag_prefix = 'grover-'
+      @ignore_path = nil
       @use_pdf_middleware = true
       @use_png_middleware = false
       @use_jpeg_middleware = false

--- a/lib/grover/configuration.rb
+++ b/lib/grover/configuration.rb
@@ -5,11 +5,14 @@ class Grover
   # Configuration of the options for Grover HTML to PDF conversion
   #
   class Configuration
-    attr_accessor :options, :meta_tag_prefix
+    attr_accessor :options, :meta_tag_prefix, :use_pdf_middleware, :use_png_middleware, :use_jpeg_middleware
 
     def initialize
       @options = {}
       @meta_tag_prefix = 'grover-'
+      @use_pdf_middleware = true
+      @use_png_middleware = false
+      @use_jpeg_middleware = false
     end
   end
 end

--- a/lib/grover/middleware.rb
+++ b/lib/grover/middleware.rb
@@ -35,12 +35,11 @@ class Grover
     JPEG_REGEX = /\.jpe?g$/i.freeze
 
     attr_reader :pdf_request, :png_request, :jpeg_request
-    delegate :ignore_path, :use_pdf_middleware, :use_png_middleware, :use_jpeg_middleware, to: 'Grover.configuration'
 
     def identify_request_type
-      @pdf_request = use_pdf_middleware && path_matches?(PDF_REGEX)
-      @png_request = use_png_middleware && path_matches?(PNG_REGEX)
-      @jpeg_request = use_jpeg_middleware && path_matches?(JPEG_REGEX)
+      @pdf_request = Grover.configuration.use_pdf_middleware && path_matches?(PDF_REGEX)
+      @png_request = Grover.configuration.use_png_middleware && path_matches?(PNG_REGEX)
+      @jpeg_request = Grover.configuration.use_jpeg_middleware && path_matches?(JPEG_REGEX)
     end
 
     def path_matches?(regex)
@@ -52,6 +51,7 @@ class Grover
     end
 
     def ignore_request?
+      ignore_path = Grover.configuration.ignore_path
       case ignore_path
       when String then @request.path.start_with? ignore_path
       when Regexp then ignore_path.match? @request.path

--- a/lib/grover/middleware.rb
+++ b/lib/grover/middleware.rb
@@ -54,7 +54,7 @@ class Grover
       ignore_path = Grover.configuration.ignore_path
       case ignore_path
       when String then @request.path.start_with? ignore_path
-      when Regexp then ignore_path.match? @request.path
+      when Regexp then !ignore_path.match(@request.path).nil?
       when Proc then ignore_path.call @request.path
       end
     end

--- a/lib/grover/middleware.rb
+++ b/lib/grover/middleware.rb
@@ -12,21 +12,18 @@ class Grover
   class Middleware
     def initialize(app)
       @app = app
-      @render_pdf = false
+      @pdf_request = false
+      @png_request = false
+      @jpeg_request = false
     end
 
     def call(env)
       @request = Rack::Request.new(env)
-      @render_pdf = pdf_request?
+      identify_request_type
 
-      configure_env_for_pdf_request(env) if rendering_pdf?
+      configure_env_for_grover_request(env) if grover_request?
       status, headers, response = @app.call(env)
-
-      if rendering_pdf? && html_content?(headers)
-        pdf = convert_to_pdf response
-        response = [pdf]
-        update_headers headers, pdf
-      end
+      response = update_response response, headers if grover_request? && html_content?(headers)
 
       [status, headers, response]
     end
@@ -34,21 +31,42 @@ class Grover
     private
 
     PDF_REGEX = /\.pdf$/i.freeze
+    PNG_REGEX = /\.png$/i.freeze
+    JPEG_REGEX = /\.jpe?g$/i.freeze
 
-    def rendering_pdf?
-      @render_pdf
+    attr_reader :pdf_request, :png_request, :jpeg_request
+
+    def identify_request_type
+      @pdf_request = Grover.configuration.use_pdf_middleware && !@request.path.match(PDF_REGEX).nil?
+      @png_request = Grover.configuration.use_png_middleware && !@request.path.match(PNG_REGEX).nil?
+      @jpeg_request = Grover.configuration.use_jpeg_middleware && !@request.path.match(JPEG_REGEX).nil?
     end
 
-    def pdf_request?
-      !@request.path.match(PDF_REGEX).nil?
+    def grover_request?
+      pdf_request || png_request || jpeg_request
     end
 
     def html_content?(headers)
       headers['Content-Type'] =~ %r{text/html|application/xhtml\+xml}
     end
 
-    def convert_to_pdf(response)
+    def update_response(response, headers)
       grover = create_grover_for_response(response)
+
+      body, content_type =
+        if pdf_request
+          [convert_to_pdf(grover), 'application/pdf']
+        elsif png_request
+          [grover.to_png, 'image/png']
+        elsif jpeg_request
+          [grover.to_jpeg, 'image/jpeg']
+        end
+
+      assign_headers headers, body, content_type
+      [body]
+    end
+
+    def convert_to_pdf(grover)
       if grover.show_front_cover? || grover.show_back_cover?
         add_cover_content grover
       else
@@ -80,16 +98,16 @@ class Grover
       CombinePDF.parse grover.to_pdf
     end
 
-    def update_headers(headers, body)
-      # Do not cache PDFs
+    def assign_headers(headers, body, content_type)
+      # Do not cache results
       headers.delete 'ETag'
       headers.delete 'Cache-Control'
 
       headers['Content-Length'] = (body.respond_to?(:bytesize) ? body.bytesize : body.size).to_s
-      headers['Content-Type'] = 'application/pdf'
+      headers['Content-Type'] = content_type
     end
 
-    def configure_env_for_pdf_request(env)
+    def configure_env_for_grover_request(env)
       env['PATH_INFO'] = env['REQUEST_URI'] = path_without_extension
       env['HTTP_ACCEPT'] = concat(env['HTTP_ACCEPT'], Rack::Mime.mime_type('.html'))
       env['Rack-Middleware-Grover'] = 'true'
@@ -108,7 +126,17 @@ class Grover
     end
 
     def path_without_extension
-      @request.path.sub(PDF_REGEX, '').sub(@request.script_name, '')
+      @request.path.sub(request_regex, '').sub(@request.script_name, '')
+    end
+
+    def request_regex
+      if pdf_request
+        PDF_REGEX
+      elsif png_request
+        PNG_REGEX
+      elsif jpeg_request
+        JPEG_REGEX
+      end
     end
 
     def request_url

--- a/spec/grover/middleware_spec.rb
+++ b/spec/grover/middleware_spec.rb
@@ -51,6 +51,54 @@ describe Grover::Middleware do
         end
       end
 
+      context 'when requesting a PNG' do
+        before { allow(Grover.configuration).to receive(:use_png_middleware).and_return true }
+
+        it 'returns PNG content type' do
+          get 'http://www.example.org/test.png'
+          expect(last_response.headers['Content-Type']).to eq 'image/png'
+          response_size = Grover.new('Grover McGroveryface').to_png.bytesize
+          expect(last_response.body.bytesize).to eq response_size
+          expect(last_response.headers['Content-Length']).to eq response_size.to_s
+        end
+
+        it 'matches PNG case insensitive' do
+          get 'http://www.example.org/test.PNG'
+          expect(last_response.headers['Content-Type']).to eq 'image/png'
+          response_size = Grover.new('Grover McGroveryface').to_png.bytesize
+          expect(last_response.body.bytesize).to eq response_size
+          expect(last_response.headers['Content-Length']).to eq response_size.to_s
+        end
+      end
+
+      context 'when requesting a JPEG' do
+        before { allow(Grover.configuration).to receive(:use_jpeg_middleware).and_return true }
+
+        it 'returns JPEG content type' do
+          get 'http://www.example.org/test.jpeg'
+          expect(last_response.headers['Content-Type']).to eq 'image/jpeg'
+          response_size = Grover.new('Grover McGroveryface').to_jpeg.bytesize
+          expect(last_response.body.bytesize).to eq response_size
+          expect(last_response.headers['Content-Length']).to eq response_size.to_s
+        end
+
+        it 'matches JPEG case insensitive' do
+          get 'http://www.example.org/test.JPEG'
+          expect(last_response.headers['Content-Type']).to eq 'image/jpeg'
+          response_size = Grover.new('Grover McGroveryface').to_jpeg.bytesize
+          expect(last_response.body.bytesize).to eq response_size
+          expect(last_response.headers['Content-Length']).to eq response_size.to_s
+        end
+
+        it 'matches JPG case insensitive' do
+          get 'http://www.example.org/test.JPG'
+          expect(last_response.headers['Content-Type']).to eq 'image/jpeg'
+          response_size = Grover.new('Grover McGroveryface').to_jpeg.bytesize
+          expect(last_response.body.bytesize).to eq response_size
+          expect(last_response.headers['Content-Length']).to eq response_size.to_s
+        end
+      end
+
       context 'when request doesnt have an extension' do
         it 'returns the downstream content type' do
           get 'http://www.example.org/test'
@@ -60,7 +108,7 @@ describe Grover::Middleware do
         end
       end
 
-      context 'when request has a non-PDF extension' do
+      context 'when request has a non-PDF/PNG/JPEG extension' do
         it 'returns the downstream content type' do
           get 'http://www.example.org/test.html'
           expect(last_response.headers['Content-Type']).to eq 'text/html'
@@ -79,9 +127,74 @@ describe Grover::Middleware do
           expect(@env['REQUEST_URI']).to eq '/test'
           expect(@env['Rack-Middleware-Grover']).to eq 'true'
         end
+
+        context 'when app configuration has PDF middleware disabled' do
+          before { allow(Grover.configuration).to receive(:use_pdf_middleware).and_return false }
+
+          it 'doesnt assign path environment variables' do
+            get 'http://www.example.org/test.pdf'
+            expect(@env['PATH_INFO']).to eq '/test.pdf'
+            expect(@env).not_to have_key 'REQUEST_URI'
+            expect(@env).not_to have_key 'Rack-Middleware-Grover'
+          end
+        end
       end
 
-      context 'when not requesting a PDF' do
+      context 'when requesting a PNG' do
+        it 'doesnt assign path environment variables' do
+          get 'http://www.example.org/test.png'
+          expect(@env['PATH_INFO']).to eq '/test.png'
+          expect(@env).not_to have_key 'REQUEST_URI'
+          expect(@env).not_to have_key 'Rack-Middleware-Grover'
+        end
+
+        context 'when app configuration has PNG middleware enabled' do
+          before { allow(Grover.configuration).to receive(:use_png_middleware).and_return true }
+
+          it 'removes PNG extension from PATH_INFO and REQUEST_URI' do
+            get 'http://www.example.org/test.png'
+            expect(@env['PATH_INFO']).to eq '/test'
+            expect(@env['REQUEST_URI']).to eq '/test'
+            expect(@env['Rack-Middleware-Grover']).to eq 'true'
+          end
+        end
+      end
+
+      context 'when requesting a JPEG' do
+        it 'doesnt assign path environment variables for JPEG' do
+          get 'http://www.example.org/test.jpeg'
+          expect(@env['PATH_INFO']).to eq '/test.jpeg'
+          expect(@env).not_to have_key 'REQUEST_URI'
+          expect(@env).not_to have_key 'Rack-Middleware-Grover'
+        end
+
+        it 'doesnt assign path environment variables for JPG' do
+          get 'http://www.example.org/test.jpg'
+          expect(@env['PATH_INFO']).to eq '/test.jpg'
+          expect(@env).not_to have_key 'REQUEST_URI'
+          expect(@env).not_to have_key 'Rack-Middleware-Grover'
+        end
+
+        context 'when app configuration has JPEG middleware enabled' do
+          before { allow(Grover.configuration).to receive(:use_jpeg_middleware).and_return true }
+
+          it 'removes JPEG extension from PATH_INFO and REQUEST_URI' do
+            get 'http://www.example.org/test.jpeg'
+            expect(@env['PATH_INFO']).to eq '/test'
+            expect(@env['REQUEST_URI']).to eq '/test'
+            expect(@env['Rack-Middleware-Grover']).to eq 'true'
+          end
+
+          it 'removes JPG extension from PATH_INFO and REQUEST_URI' do
+            get 'http://www.example.org/test.jpg'
+            expect(@env['PATH_INFO']).to eq '/test'
+            expect(@env['REQUEST_URI']).to eq '/test'
+            expect(@env['Rack-Middleware-Grover']).to eq 'true'
+          end
+        end
+      end
+
+      context 'when not requesting a PDF/PNG or JPEG' do
         it 'keeps the original PATH_INFO and not change to REQUEST_URI' do
           get 'http://www.example.org/test.html'
           expect(@env['PATH_INFO']).to eq '/test.html'
@@ -99,9 +212,61 @@ describe Grover::Middleware do
           expect(last_response.headers).not_to have_key 'ETag'
           expect(last_response.headers).not_to have_key 'Cache-Control'
         end
+
+        context 'when app configuration has PDF middleware disabled' do
+          before { allow(Grover.configuration).to receive(:use_pdf_middleware).and_return false }
+
+          it 'returns the cache headers' do
+            get 'http://www.example.org/test.pdf'
+            expect(last_response.headers['ETag']).to eq 'foo'
+            expect(last_response.headers['Cache-Control']).to eq 'max-age=2592000, public'
+          end
+        end
       end
 
-      context 'when not requesting a PDF' do
+      context 'when requesting a PNG' do
+        it 'returns the cache headers' do
+          get 'http://www.example.org/test.png'
+          expect(last_response.headers['ETag']).to eq 'foo'
+          expect(last_response.headers['Cache-Control']).to eq 'max-age=2592000, public'
+        end
+
+        context 'when app configuration has PNG middleware enabled' do
+          before { allow(Grover.configuration).to receive(:use_png_middleware).and_return true }
+
+          it 'deletes the cache headers' do
+            get 'http://www.example.org/test.png'
+            expect(last_response.headers).not_to have_key 'ETag'
+            expect(last_response.headers).not_to have_key 'Cache-Control'
+          end
+        end
+      end
+
+      context 'when requesting a JPEG' do
+        it 'returns the cache headers' do
+          get 'http://www.example.org/test.jpeg'
+          expect(last_response.headers['ETag']).to eq 'foo'
+          expect(last_response.headers['Cache-Control']).to eq 'max-age=2592000, public'
+        end
+
+        context 'when app configuration has JPEG middleware enabled' do
+          before { allow(Grover.configuration).to receive(:use_jpeg_middleware).and_return true }
+
+          it 'deletes the cache headers for JPEG' do
+            get 'http://www.example.org/test.jpeg'
+            expect(last_response.headers).not_to have_key 'ETag'
+            expect(last_response.headers).not_to have_key 'Cache-Control'
+          end
+
+          it 'deletes the cache headers for JPG' do
+            get 'http://www.example.org/test.jpg'
+            expect(last_response.headers).not_to have_key 'ETag'
+            expect(last_response.headers).not_to have_key 'Cache-Control'
+          end
+        end
+      end
+
+      context 'when not requesting a PDF, PNG or JPEG' do
         it 'returns the cache headers' do
           get 'http://www.example.org/test'
           expect(last_response.headers['ETag']).to eq 'foo'
@@ -118,6 +283,60 @@ describe Grover::Middleware do
           get 'http://www.example.org/test.pdf'
           expect(last_response.headers['Content-Type']).to eq 'application/pdf'
           expect(last_response.body.bytesize).to eq Grover.new('Rackalicious').to_pdf.bytesize
+        end
+
+        context 'when app configuration has PDF middleware disabled' do
+          before { allow(Grover.configuration).to receive(:use_pdf_middleware).and_return false }
+
+          it 'returns response as text (original)' do
+            get 'http://www.example.org/test.pdf'
+            expect(last_response.headers['Content-Type']).to eq 'text/html'
+            expect(last_response.body).to eq 'Rackalicious'
+          end
+        end
+
+        it 'returns PNG response as text (original)' do
+          get 'http://www.example.org/test.png'
+          expect(last_response.headers['Content-Type']).to eq 'text/html'
+          expect(last_response.body).to eq 'Rackalicious'
+        end
+
+        context 'when app configuration has PNG middleware enabled' do
+          before { allow(Grover.configuration).to receive(:use_png_middleware).and_return true }
+
+          it 'returns response as PNG' do
+            get 'http://www.example.org/test.png'
+            expect(last_response.headers['Content-Type']).to eq 'image/png'
+            expect(last_response.body.bytesize).to eq Grover.new('Rackalicious').to_png.bytesize
+          end
+        end
+
+        it 'returns JPEG response as text (original)' do
+          get 'http://www.example.org/test.jpeg'
+          expect(last_response.headers['Content-Type']).to eq 'text/html'
+          expect(last_response.body).to eq 'Rackalicious'
+        end
+
+        it 'returns JPG response as text (original)' do
+          get 'http://www.example.org/test.jpg'
+          expect(last_response.headers['Content-Type']).to eq 'text/html'
+          expect(last_response.body).to eq 'Rackalicious'
+        end
+
+        context 'when app configuration has JPEG middleware enabled' do
+          before { allow(Grover.configuration).to receive(:use_jpeg_middleware).and_return true }
+
+          it 'returns response as JPEG' do
+            get 'http://www.example.org/test.jpeg'
+            expect(last_response.headers['Content-Type']).to eq 'image/jpeg'
+            expect(last_response.body.bytesize).to eq Grover.new('Rackalicious').to_jpeg.bytesize
+          end
+
+          it 'returns response as JPG' do
+            get 'http://www.example.org/test.jpg'
+            expect(last_response.headers['Content-Type']).to eq 'image/jpeg'
+            expect(last_response.body.bytesize).to eq Grover.new('Rackalicious').to_jpeg.bytesize
+          end
         end
       end
 
@@ -156,6 +375,66 @@ describe Grover::Middleware do
         expect(grover).to receive(:to_pdf).with(no_args).and_return 'A converted PDF'
         get 'http://www.example.org/test.pdf'
         expect(last_response.body).to eq 'A converted PDF'
+      end
+
+      context 'when app configuration has PDF middleware disabled' do
+        before { allow(Grover.configuration).to receive(:use_pdf_middleware).and_return false }
+
+        it 'doesnt call to Grover' do
+          expect(Grover).not_to receive(:new)
+          get 'http://www.example.org/test.pdf'
+          expect(last_response.body).to eq 'Grover McGroveryface'
+        end
+      end
+    end
+
+    describe 'png conversion' do
+      let(:grover) { instance_double Grover, show_front_cover?: false, show_back_cover?: false }
+
+      it 'doesnt call to Grover' do
+        expect(Grover).not_to receive(:new)
+        get 'http://www.example.org/test.png'
+        expect(last_response.body).to eq 'Grover McGroveryface'
+      end
+
+      context 'when app configuration has PNG middleware enabled' do
+        before { allow(Grover.configuration).to receive(:use_png_middleware).and_return true }
+
+        it 'passes through the request URL (sans extension) to Grover' do
+          expect(Grover).to(
+            receive(:new).
+              with('Grover McGroveryface', display_url: 'http://www.example.org/test').
+              and_return(grover)
+          )
+          expect(grover).to receive(:to_png).with(no_args).and_return 'A converted PNG'
+          get 'http://www.example.org/test.png'
+          expect(last_response.body).to eq 'A converted PNG'
+        end
+      end
+    end
+
+    describe 'jpeg conversion' do
+      let(:grover) { instance_double Grover, show_front_cover?: false, show_back_cover?: false }
+
+      it 'doesnt call to Grover' do
+        expect(Grover).not_to receive(:new)
+        get 'http://www.example.org/test.jpeg'
+        expect(last_response.body).to eq 'Grover McGroveryface'
+      end
+
+      context 'when app configuration has JPEG middleware enabled' do
+        before { allow(Grover.configuration).to receive(:use_jpeg_middleware).and_return true }
+
+        it 'passes through the request URL (sans extension) to Grover' do
+          expect(Grover).to(
+            receive(:new).
+              with('Grover McGroveryface', display_url: 'http://www.example.org/test').
+              and_return(grover)
+          )
+          expect(grover).to receive(:to_jpeg).with(no_args).and_return 'A converted JPEG'
+          get 'http://www.example.org/test.jpeg'
+          expect(last_response.body).to eq 'A converted JPEG'
+        end
       end
     end
 
@@ -232,21 +511,190 @@ describe Grover::Middleware do
       end
     end
 
-    it 'does not get stuck rendering each request as pdf' do
-      # false by default. No requests.
-      expect(mock_app.send(:rendering_pdf?)).to eq false
+    describe '#grover_request?' do
+      it 'does not get stuck rendering each request as pdf' do
+        # false by default. No requests.
+        expect(mock_app.send(:grover_request?)).to eq false
 
-      # Remain false on a normal request
-      get 'http://www.example.org/test.html'
-      expect(mock_app.send(:rendering_pdf?)).to eq false
+        # Remain false on a normal request
+        get 'http://www.example.org/test.html'
+        expect(mock_app.send(:grover_request?)).to eq false
 
-      # Return true on a pdf request.
-      get 'http://www.example.org/test.pdf'
-      expect(mock_app.send(:rendering_pdf?)).to eq true
+        # Return true on a pdf request.
+        get 'http://www.example.org/test.pdf'
+        expect(mock_app.send(:grover_request?)).to eq true
 
-      # Restore to false on any non-pdf request.
-      get 'http://www.example.org/test'
-      expect(mock_app.send(:rendering_pdf?)).to eq false
+        # Restore to false on any non-pdf request.
+        get 'http://www.example.org/test'
+        expect(mock_app.send(:grover_request?)).to eq false
+      end
+
+      context 'when app configuration has PDF middleware disabled' do
+        before { allow(Grover.configuration).to receive(:use_pdf_middleware).and_return false }
+
+        it 'does not handle pdf requests' do
+          # false by default. No requests.
+          expect(mock_app.send(:grover_request?)).to eq false
+
+          # Return false on a pdf request.
+          get 'http://www.example.org/test.pdf'
+          expect(mock_app.send(:grover_request?)).to eq false
+        end
+      end
+
+      it 'does not handle png requests' do
+        # false by default. No requests.
+        expect(mock_app.send(:grover_request?)).to eq false
+
+        # Return false on a png request.
+        get 'http://www.example.org/test.png'
+        expect(mock_app.send(:grover_request?)).to eq false
+      end
+
+      context 'when app configuration has PNG middleware enabled' do
+        before { allow(Grover.configuration).to receive(:use_png_middleware).and_return true }
+
+        it 'does not get stuck rendering each request as png' do
+          # false by default. No requests.
+          expect(mock_app.send(:grover_request?)).to eq false
+
+          # Remain false on a normal request
+          get 'http://www.example.org/test.html'
+          expect(mock_app.send(:grover_request?)).to eq false
+
+          # Return true on a png request.
+          get 'http://www.example.org/test.png'
+          expect(mock_app.send(:grover_request?)).to eq true
+
+          # Restore to false on any non-png request.
+          get 'http://www.example.org/test'
+          expect(mock_app.send(:grover_request?)).to eq false
+        end
+      end
+
+      it 'does not handle jpeg requests' do
+        # false by default. No requests.
+        expect(mock_app.send(:grover_request?)).to eq false
+
+        # Return false on a jpeg request.
+        get 'http://www.example.org/test.jpeg'
+        expect(mock_app.send(:grover_request?)).to eq false
+      end
+
+      it 'does not handle jpg requests' do
+        # false by default. No requests.
+        expect(mock_app.send(:grover_request?)).to eq false
+
+        # Return false on a jpg request.
+        get 'http://www.example.org/test.jpg'
+        expect(mock_app.send(:grover_request?)).to eq false
+      end
+
+      context 'when app configuration has JPEG middleware enabled' do
+        before { allow(Grover.configuration).to receive(:use_jpeg_middleware).and_return true }
+
+        it 'does not get stuck rendering each request as jpeg' do
+          # false by default. No requests.
+          expect(mock_app.send(:grover_request?)).to eq false
+
+          # Remain false on a normal request
+          get 'http://www.example.org/test.html'
+          expect(mock_app.send(:grover_request?)).to eq false
+
+          # Return true on a jpeg request.
+          get 'http://www.example.org/test.jpeg'
+          expect(mock_app.send(:grover_request?)).to eq true
+
+          # Restore to false on any non-jpeg request.
+          get 'http://www.example.org/test'
+          expect(mock_app.send(:grover_request?)).to eq false
+        end
+
+        it 'does not get stuck rendering each request as jpg' do
+          # false by default. No requests.
+          expect(mock_app.send(:grover_request?)).to eq false
+
+          # Remain false on a normal request
+          get 'http://www.example.org/test.html'
+          expect(mock_app.send(:grover_request?)).to eq false
+
+          # Return true on a jpg request.
+          get 'http://www.example.org/test.jpg'
+          expect(mock_app.send(:grover_request?)).to eq true
+
+          # Restore to false on any non-jpeg request.
+          get 'http://www.example.org/test'
+          expect(mock_app.send(:grover_request?)).to eq false
+        end
+      end
+    end
+
+    describe '#ignore_path?' do
+      context 'when app configuration has a String for ignore_path' do
+        before { allow(Grover.configuration).to receive(:ignore_path).and_return '/foo/bar' }
+
+        it 'request is ignored when the request path starts with the ignore_path' do
+          get 'http://www.example.org/foo/bar/baz'
+          expect(mock_app.send(:ignore_request?)).to eq true
+          expect(mock_app.send(:grover_request?)).to eq false
+
+          get 'http://www.example.org/foo/bar/baz.pdf'
+          expect(mock_app.send(:ignore_request?)).to eq true
+          expect(mock_app.send(:grover_request?)).to eq false
+
+          get 'http://www.example.org/foo/baz/bar'
+          expect(mock_app.send(:ignore_request?)).to eq false
+          expect(mock_app.send(:grover_request?)).to eq false
+
+          get 'http://www.example.org/foo/baz/bar.pdf'
+          expect(mock_app.send(:ignore_request?)).to eq false
+          expect(mock_app.send(:grover_request?)).to eq true
+        end
+      end
+
+      context 'when app configuration has a Regexp for ignore_path' do
+        before { allow(Grover.configuration).to receive(:ignore_path).and_return %r{foo/bar} }
+
+        it 'request is ignored when the request path matches the ignore_path' do
+          get 'http://www.example.org/baz/foo/bar/baz'
+          expect(mock_app.send(:ignore_request?)).to eq true
+          expect(mock_app.send(:grover_request?)).to eq false
+
+          get 'http://www.example.org/baz/foo/bar/baz.pdf'
+          expect(mock_app.send(:ignore_request?)).to eq true
+          expect(mock_app.send(:grover_request?)).to eq false
+
+          get 'http://www.example.org/bar/foo/baz/bar'
+          expect(mock_app.send(:ignore_request?)).to eq false
+          expect(mock_app.send(:grover_request?)).to eq false
+
+          get 'http://www.example.org/bar/foo/baz/bar.pdf'
+          expect(mock_app.send(:ignore_request?)).to eq false
+          expect(mock_app.send(:grover_request?)).to eq true
+        end
+      end
+
+      context 'when app configuration has a Proc for ignore_path' do
+        before { allow(Grover.configuration).to receive(:ignore_path).and_return(->(path) { path.include? 'baz' }) }
+
+        it 'request is ignored when the request path passed to the proc defined in ignore_path returns true' do
+          get 'http://www.example.org/foobazbar'
+          expect(mock_app.send(:ignore_request?)).to eq true
+          expect(mock_app.send(:grover_request?)).to eq false
+
+          get 'http://www.example.org/foobazbar.pdf'
+          expect(mock_app.send(:ignore_request?)).to eq true
+          expect(mock_app.send(:grover_request?)).to eq false
+
+          get 'http://www.example.org/foobarbar'
+          expect(mock_app.send(:ignore_request?)).to eq false
+          expect(mock_app.send(:grover_request?)).to eq false
+
+          get 'http://www.example.org/foobarbar.pdf'
+          expect(mock_app.send(:ignore_request?)).to eq false
+          expect(mock_app.send(:grover_request?)).to eq true
+        end
+      end
     end
 
     context 'with a downstream app that can respond to different paths' do

--- a/spec/grover_spec.rb
+++ b/spec/grover_spec.rb
@@ -304,7 +304,7 @@ describe Grover do
 
       # don't really want to rely on pixel testing the website screenshot
       # so we'll check it's mean colour is roughly what we expect
-      it { expect(image.data.dig('imageStatistics', 'all', 'mean').to_f).to be_within(0.5).of 188.4 }
+      it { expect(image.data.dig('imageStatistics', 'all', 'mean').to_f).to be_within(5).of 188.4 }
     end
 
     context 'when passing through html' do


### PR DESCRIPTION
Adds Rack middleware that identifies requests with PNG, JPEG or JPG extensions and calls the downstream app with the extension removed, then converts the resulting response to an image (if the response is HTML) - ie same as PDF requests. The default behaviour is for these requests to remain unchanged unless the app configuration enables them.

Adds ability to ignore requests based on path and pass them through the app without modification