### PR TITLE
Add ability to set `viewport` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Added
 - [#25](https://github.com/Studiosity/grover/pull/25) Add support for capturing PNG/JPEG screenshots
 - [#27](https://github.com/Studiosity/grover/pull/27) Add support for PNG/JPEG middleware requests
-- Add support for `viewport` options (passed in to `page.setViewport` before the page is rendered)
+- [#28](https://github.com/Studiosity/grover/pull/28) Add support for `viewport` options (passed in to `page.setViewport` before the page is rendered)
 
 ## [0.7.4](releases/tag/v0.7.4) - 2019-07-09
 ### Breaking change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 - [#25](https://github.com/Studiosity/grover/pull/25) Add support for capturing PNG/JPEG screenshots
 - [#27](https://github.com/Studiosity/grover/pull/27) Add support for PNG/JPEG middleware requests
+- Add support for `viewport` options (passed in to `page.setViewport` before the page is rendered)
 
 ## [0.7.4](releases/tag/v0.7.4) - 2019-07-09
 ### Breaking change

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Grover can be configured to adjust the layout of the resulting PDF/image.
 
 For available PDF options, see https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagepdfoptions
 
-Also available are the `emulate_media`, `cache` and `timeout` options.
+Also available are the `emulate_media`, `cache`, `viewport` and `timeout` options.
 
 ```ruby
 # config/initializers/grover.rb
@@ -94,6 +94,10 @@ Grover.configure do |config|
     margin: {
       top: '5px',
       bottom: '10cm'
+    },
+    viewport: {
+      width: 640,
+      height: 480
     },
     prefer_css_page_size: true,
     emulate_media: 'screen',
@@ -106,7 +110,9 @@ end
 For available PNG/JPEG options, see https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagescreenshotoptions
 
 Note that by default the `full_page` option is set to false and you will get a 800x600 image. You can either specify
-the image size using the `clip` options, or capture the entire page with `full_page` set to `true`. 
+the image size using the `clip` options, or capture the entire page with `full_page` set to `true`.
+
+For `viewport` options, see https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagesetviewportviewport 
 
 #### Page URL for middleware requests (or passing through raw HTML)
 If you want to have the header or footer display the page URL, Grover requires that this is passed through via the

--- a/lib/grover.rb
+++ b/lib/grover.rb
@@ -57,6 +57,12 @@ class Grover
               request_options.timeout = timeout;
             }
 
+            // Setup viewport options (if provided)
+            const viewport = options.viewport; delete options.viewport;
+            if (viewport != undefined) {
+              await page.setViewport(viewport);
+            }
+
             if (url_or_html.match(/^http/i)) {
               // Request is for a URL, so request it
               request_options.waitUntil = 'networkidle2';

--- a/spec/grover_spec.rb
+++ b/spec/grover_spec.rb
@@ -316,7 +316,7 @@ describe Grover do
       it { expect(mean_colour_statistics(image)).to eq %w[0 0 255] }
     end
 
-    context 'when passing through options to Grover' do
+    context 'when passing through clip options to Grover' do
       let(:url_or_html) { '<html><body style="background-color: red"></body></html>' }
       let(:options) { { clip: { x: 0, y: 0, width: 200, height: 100 } } }
 
@@ -324,6 +324,16 @@ describe Grover do
       it { expect(image.type).to eq 'PNG' }
       it { expect(image.dimensions).to eq [200, 100] }
       it { expect(mean_colour_statistics(image)).to eq %w[255 0 0] }
+    end
+
+    context 'when passing through viewport options to Grover' do
+      let(:url_or_html) { '<html><body style="background-color: brown"></body></html>' }
+      let(:options) { { viewport: { width: 400, height: 500 } } }
+
+      it { expect(screenshot.unpack('C*')).to start_with "\x89PNG\r\n\x1A\n".unpack('C*') }
+      it { expect(image.type).to eq 'PNG' }
+      it { expect(image.dimensions).to eq [400, 500] }
+      it { expect(mean_colour_statistics(image)).to eq %w[165 42 42] }
     end
   end
 


### PR DESCRIPTION
Implements `page.setViewport` in the conversion process allowing configuration of page width/height,  and various other viewport options