### PR TITLE
Add configuration option `args`

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Grover can be configured to adjust the layout of the resulting PDF/image.
 
 For available PDF options, see https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagepdfoptions
 
-Also available are the `emulate_media`, `cache`, `viewport` and `timeout` options.
+Also available are the `emulate_media`, `cache`, `viewport`, `timeout`, and `args` options.
 
 ```ruby
 # config/initializers/grover.rb
@@ -102,7 +102,8 @@ Grover.configure do |config|
     prefer_css_page_size: true,
     emulate_media: 'screen',
     cache: false,
-    timeout: 0 # Timeout in ms. A value of `0` means 'no timeout'
+    timeout: 0, # Timeout in ms. A value of `0` means 'no timeout'
+    args: ['--font-render-hinting=medium'] # Chromium flags: http://peter.sh/experiments/chromium-command-line-switches/ 
   }
 end
 ```

--- a/lib/grover.rb
+++ b/lib/grover.rb
@@ -23,7 +23,7 @@ class Grover
     dependencies puppeteer: 'puppeteer'
 
     def self.launch_params
-      ENV['GROVER_NO_SANDBOX'] == 'true' ? "{args: ['--no-sandbox', '--disable-setuid-sandbox']}" : '{}'
+      ENV['GROVER_NO_SANDBOX'] == 'true' ? "{args: ['--no-sandbox', '--disable-setuid-sandbox']}" : '{args: []}'
     end
 
     def self.convert_function(convert_action)
@@ -38,6 +38,12 @@ class Grover
             if (typeof debug === 'object' && !!debug) {
               if (debug.headless != undefined) { launchParams.headless = debug.headless; }
               if (debug.devtools != undefined) { launchParams.devtools = debug.devtools; }
+            }
+
+            // Configure additional launch arguments
+            const args = options.args; delete options.args;
+            if (Array.isArray(args)) {
+              launchParams.args = launchParams.args.concat(args);
             }
 
             // Launch the browser and create a page


### PR DESCRIPTION
Useful for adding custom Chromium command line switches (e.g. `--font-render-hinting=none`).