### PR TITLE
Allow launch param args to be provided via configuration/meta

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,9 @@ Metrics/ClassLength:
 Metrics/LineLength:
   Max: 120
 
+RSpec/EmptyLineAfterExample:
+  Enabled: false
+
 RSpec/ExampleLength:
   Max: 12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## Unreleased
-- None
+### Added
+- [#31](https://github.com/Studiosity/grover/pull/31) Add support for launch parameter args ([@joergschiller][])
 
 ## [0.8.1](releases/tag/v0.8.1) - 2019-07-13
 ### Breaking change
@@ -146,3 +147,4 @@
 - Initial gem framework 
 
 [@koenhandekyn]: https://github.com/koenhandekyn
+[@joergschiller]: https://github.com/joergschiller

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Grover can be configured to adjust the layout of the resulting PDF/image.
 
 For available PDF options, see https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagepdfoptions
 
-Also available are the `emulate_media`, `cache`, `viewport` and `timeout` options.
+Also available are the `emulate_media`, `cache`, `viewport`, `timeout` and `launch_args` options.
 
 ```ruby
 # config/initializers/grover.rb
@@ -102,7 +102,8 @@ Grover.configure do |config|
     prefer_css_page_size: true,
     emulate_media: 'screen',
     cache: false,
-    timeout: 0 # Timeout in ms. A value of `0` means 'no timeout'
+    timeout: 0, # Timeout in ms. A value of `0` means 'no timeout'
+    launch_args: ['--font-render-hinting=medium'] 
   }
 end
 ```
@@ -112,7 +113,14 @@ For available PNG/JPEG options, see https://github.com/GoogleChrome/puppeteer/bl
 Note that by default the `full_page` option is set to false and you will get a 800x600 image. You can either specify
 the image size using the `clip` options, or capture the entire page with `full_page` set to `true`.
 
-For `viewport` options, see https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagesetviewportviewport 
+For `viewport` options, see https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagesetviewportviewport
+
+For `launch_args` options, see http://peter.sh/experiments/chromium-command-line-switches/
+Launch parameter args can also be provided using a meta tag:
+
+```html
+<meta name="grover-launch_args" content="['--disable-speech-api']" />
+``` 
 
 #### Page URL for middleware requests (or passing through raw HTML)
 If you want to have the header or footer display the page URL, Grover requires that this is passed through via the

--- a/grover.gemspec
+++ b/grover.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.summary     = <<~SUMMARY.delete("\n")
     A Ruby gem to transform HTML into PDF, PNG or JPEG by wrapping the NodeJS Google Puppeteer driver for Chromium
   SUMMARY
-  spec.homepage    = 'http://github.com/Studiosity/grover'
+  spec.homepage    = 'https://github.com/Studiosity/grover'
   spec.license     = 'MIT'
 
   spec.files         = `git ls-files lib`.split("\n")

--- a/spec/grover_spec.rb
+++ b/spec/grover_spec.rb
@@ -263,7 +263,7 @@ describe Grover do
                   var speechSupported = "webkitSpeechRecognition" in window;
                   document.getElementById("test").innerHTML = speechSupported ? "supported" : "not supported"
                 </script>
-              </body>    
+              </body>
             </html>
           HTML
         end
@@ -278,7 +278,7 @@ describe Grover do
         end
 
         context 'when disabling speech API via launch params in meta tags' do
-          let(:head) { %{<meta name="grover-launch_args" content="['--disable-speech-api']" />} }
+          let(:head) { %(<meta name="grover-launch_args" content="['--disable-speech-api']" />) }
 
           it { expect(pdf_text_content).to eq 'Speech recognition is not supported' }
         end

--- a/spec/grover_spec.rb
+++ b/spec/grover_spec.rb
@@ -249,6 +249,40 @@ describe Grover do
           expect(pdf_text_content).to eq "#{date} Paaage Hey there http://example.com/ 1/1"
         end
       end
+
+      context 'when passing through launch params' do
+        let(:options) { { launch_args: launch_args } }
+        let(:launch_args) { [] }
+        let(:url_or_html) do
+          <<-HTML
+            <html>
+              #{head}
+              <body>
+                Speech recognition is <span id="test" />
+                <script type="text/javascript">
+                  var speechSupported = "webkitSpeechRecognition" in window;
+                  document.getElementById("test").innerHTML = speechSupported ? "supported" : "not supported"
+                </script>
+              </body>    
+            </html>
+          HTML
+        end
+        let(:head) { '' }
+
+        it { expect(pdf_text_content).to eq 'Speech recognition is supported' }
+
+        context 'when launch params specify disabling the speech API' do
+          let(:launch_args) { ['--disable-speech-api'] }
+
+          it { expect(pdf_text_content).to eq 'Speech recognition is not supported' }
+        end
+
+        context 'when disabling speech API via launch params in meta tags' do
+          let(:head) { %{<meta name="grover-launch_args" content="['--disable-speech-api']" />} }
+
+          it { expect(pdf_text_content).to eq 'Speech recognition is not supported' }
+        end
+      end
     end
 
     context 'when global options are defined' do

--- a/spec/grover_spec.rb
+++ b/spec/grover_spec.rb
@@ -338,7 +338,7 @@ describe Grover do
 
       # don't really want to rely on pixel testing the website screenshot
       # so we'll check it's mean colour is roughly what we expect
-      it { expect(image.data.dig('imageStatistics', 'all', 'mean').to_f).to be_within(5).of 188.4 }
+      it { expect(image.data.dig('imageStatistics', 'all', 'mean').to_f).to be_within(5).of 165 }
     end
 
     context 'when passing through html' do


### PR DESCRIPTION
Launch parameters can be provided either by global configuration, instance initialisation or through meta tags.

For config and initialisation, recommended format would be an array of string parameters:
```
launch_params: ['--disable-speech-api', '--no-sandbox']
```

For meta tags it can be provided as a serialised array of strings:
```
<meta name="grover-launch_args" content="['--disable-speech-api', '--no-sandbox']" />
```