### PR TITLE
Add support for new emulateMediaType in Puppeteer 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 env:
   global:
     - CC_TEST_REPORTER_ID=5cfed40102c670b5c9e509730782b751939ddbe53fc57c317b718f635bab1ce8
+  jobs:
+    - PUPPETEER_VERSION=1.20.0
+    - PUPPETEER_VERSION=2.0.0
 
 language: ruby
 rvm:
@@ -15,7 +18,7 @@ before_install:
 install:
   - bundle install --jobs=3 --retry=3
   - gem install rubocop
-  - npm install
+  - npm install puppeteer@$PUPPETEER_VERSION
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/lib/grover.rb
+++ b/lib/grover.rb
@@ -92,7 +92,11 @@ class Grover
             // If specified, emulate the media type
             const emulateMedia = options.emulateMedia; delete options.emulateMedia;
             if (emulateMedia != undefined) {
-              await page.emulateMedia(emulateMedia);
+              if (typeof page.emulateMediaType == 'function') {
+                await page.emulateMediaType(emulateMedia);
+              } else {
+                await page.emulateMedia(emulateMedia);
+              }
             }
 
             // If we're running puppeteer in headless mode, return the converted PDF

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   },
   "homepage": "https://github.com/Studiosity/grover#readme",
   "devDependencies": {
-    "puppeteer": "^1.20.0"
+    "puppeteer": "^2.0.0"
   }
 }

--- a/spec/grover_spec.rb
+++ b/spec/grover_spec.rb
@@ -352,7 +352,7 @@ describe Grover do
     let(:image) { MiniMagick::Image.read screenshot }
 
     context 'when passing through a valid URL' do
-      let(:url_or_html) { 'https://www.google.com/?gl=us' }
+      let(:url_or_html) { 'https://media.gettyimages.com/photos/tabby-cat-selfie-picture-id1151094724?s=2048x2048' }
 
       # default screenshot is PNG 800w x 600h
       it { expect(screenshot.unpack('C*')).to start_with "\x89PNG\r\n\x1A\n".unpack('C*') }
@@ -361,7 +361,7 @@ describe Grover do
 
       # don't really want to rely on pixel testing the website screenshot
       # so we'll check it's mean colour is roughly what we expect
-      it { expect(image.data.dig('imageStatistics', 'all', 'mean').to_f).to be_within(5).of 165 }
+      it { expect(image.data.dig('imageStatistics', 'all', 'mean').to_f).to eq 97.7473 }
     end
 
     context 'when passing through html' do

--- a/spec/grover_spec.rb
+++ b/spec/grover_spec.rb
@@ -361,7 +361,7 @@ describe Grover do
 
       # don't really want to rely on pixel testing the website screenshot
       # so we'll check it's mean colour is roughly what we expect
-      it { expect(image.data.dig('imageStatistics', 'all', 'mean').to_f).to eq 97.7473 }
+      it { expect(image.data.dig('imageStatistics', 'all', 'mean').to_f).to be_within(1).of 97.7473 }
     end
 
     context 'when passing through html' do


### PR DESCRIPTION
Add support for new emulateMediaType in Puppeteer 2.0.0. See [Puppeteer v2.0.0 changelog](https://github.com/puppeteer/puppeteer/releases/tag/v2.0.0)
Update Travis config to test 1.x and 2.x of Puppeteer