### PR TITLE
Add option for specifying custom executable path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## Unreleased
-- None
+### Added
+- [#34](https://github.com/Studiosity/grover/pull/34) Add support for custom executable path ([@ryansmith23][])
 
 ## [0.8.3](releases/tag/v0.8.3) - 2019-10-31
 ### Added
@@ -155,3 +156,4 @@
 
 [@koenhandekyn]: https://github.com/koenhandekyn
 [@joergschiller]: https://github.com/joergschiller
+[@ryansmith23]: https://github.com/ryansmith23

--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ Launch parameter args can also be provided using a meta tag:
 ```
 
 For `wait_until` option, default for URLs is `networkidle2` and for HTML content `networkidle0`.
-For available options see https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagegotourl-options  
+For available options see https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagegotourl-options
+
+The Chrome/Chromium executable path can be overridden with the `executable_path` option.
 
 #### Page URL for middleware requests (or passing through raw HTML)
 If you want to have the header or footer display the page URL, Grover requires that this is passed through via the

--- a/lib/grover.rb
+++ b/lib/grover.rb
@@ -47,6 +47,12 @@ class Grover
               launchParams.args = launchParams.args.concat(args);
             }
 
+            // Set executable path if given
+            const executablePath = options.executablePath; delete options.executablePath;
+            if (executablePath) {
+              launchParams.executablePath = executablePath;
+            }
+
             // Launch the browser and create a page
             browser = await puppeteer.launch(launchParams);
             const page = await browser.newPage();

--- a/spec/grover_spec.rb
+++ b/spec/grover_spec.rb
@@ -306,6 +306,16 @@ describe Grover do
           it { expect(pdf_text_content).to eq 'Delayed JavaScript did not run' }
         end
       end
+
+      context 'when options include executable_path' do
+        let(:options) { { executable_path: '/totes/invalid/path' } }
+
+        it do
+          expect do
+            to_pdf
+          end.to raise_error Schmooze::JavaScript::Error, %r{Failed to launch chrome! spawn /totes/invalid/path}
+        end
+      end
     end
 
     context 'when global options are defined' do


### PR DESCRIPTION
Based on work by @ryansmith23 https://github.com/Studiosity/grover/compare/8af71013f6076d0b5810599422271c6b75d9ca0d...epona-science:master

Allows for the executable path for Chrome/Chromium to be overridden via the `executable_path` option.