### PR TITLE
Add script execution support

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ For available options see https://github.com/GoogleChrome/puppeteer/blob/master/
 
 The Chrome/Chromium executable path can be overridden with the `executable_path` option.
 
+Javascript can be executed on the page (after render and before conversion to PDF/image)
+with the `execute_script` option.
+
 #### Basic authentication
 For requesting a page with basic authentication, `username` and `password` options can be provided. Note that this
 only really makes sense if you're calling Grover directly (and not via middleware).

--- a/lib/grover.rb
+++ b/lib/grover.rb
@@ -113,9 +113,9 @@ class Grover
             }
 
             // If specified, evaluate script on the page
-            const evaluate = options.evaluate; delete options.evaluate;
-            if (evaluate != undefined) {
-              await page.evaluate(evaluate);
+            const executeScript = options.executeScript; delete options.executeScript;
+            if (executeScript != undefined) {
+              await page.evaluate(executeScript);
             }
 
             // If we're running puppeteer in headless mode, return the converted PDF

--- a/lib/grover.rb
+++ b/lib/grover.rb
@@ -112,6 +112,12 @@ class Grover
               }
             }
 
+            // If specified, evaluate script on the page
+            const evaluate = options.evaluate; delete options.evaluate;
+            if (evaluate != undefined) {
+              await page.evaluate(evaluate);
+            }
+
             // If we're running puppeteer in headless mode, return the converted PDF
             if (debug == undefined || (typeof debug === 'object' && (debug.headless == undefined || debug.headless))) {
               return await page.#{convert_action}(options);

--- a/spec/grover_spec.rb
+++ b/spec/grover_spec.rb
@@ -366,6 +366,15 @@ describe Grover do
         it { expect(pdf_text_content).to eq 'Hey there This should only display for screen media' }
       end
     end
+
+    context 'when evaluate option is specified' do
+      let(:url_or_html) { '<html><body></body></html>' }
+      let(:options) { basic_header_footer_options.merge(evaluate: script) }
+      let(:script) { 'document.getElementsByTagName("body")[0].innerText = "Some evaluated content"' }
+      let(:date) { Date.today.strftime '%-m/%-d/%Y' }
+
+      it { expect(pdf_text_content).to eq "#{date} Some evaluated content http://www.example.net/foo/bar 1/1" }
+    end
   end
 
   describe '#screenshot' do

--- a/spec/grover_spec.rb
+++ b/spec/grover_spec.rb
@@ -369,7 +369,7 @@ describe Grover do
 
     context 'when evaluate option is specified' do
       let(:url_or_html) { '<html><body></body></html>' }
-      let(:options) { basic_header_footer_options.merge(evaluate: script) }
+      let(:options) { basic_header_footer_options.merge(execute_script: script) }
       let(:script) { 'document.getElementsByTagName("body")[0].innerText = "Some evaluated content"' }
       let(:date) { Date.today.strftime '%-m/%-d/%Y' }
 


### PR DESCRIPTION
Allow script to be provided that is executed (evaluated) after the page has been rendered but before it is converted to PDF or image