### PR TITLE
Scrub the middleware cover page request env before request

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ Metrics/BlockLength:
     - "**/*_spec.rb"
 
 Metrics/ClassLength:
-  Max: 125
+  Max: 135
 
 Metrics/LineLength:
   Max: 120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## Unreleased
-- None
+### Fixed
+- [#41](https://github.com/Studiosity/grover/pull/41) Fix middleware cover page request env scrubbing
 
 ## [0.10.1](releases/tag/v0.10.1) - 2020-01-13
 ### Fixed

--- a/lib/grover/middleware.rb
+++ b/lib/grover/middleware.rb
@@ -111,6 +111,7 @@ class Grover
 
     def fetch_cover_pdf(path)
       temp_env = env.deep_dup
+      scrub_env! temp_env
       temp_env['PATH_INFO'], temp_env['QUERY_STRING'] = path.split '?'
       _, _, response = @app.call(temp_env)
       response.close if response.respond_to? :close
@@ -165,6 +166,15 @@ class Grover
 
     def env
       @request.env
+    end
+
+    def scrub_env!(env)
+      # Reset the env to remove any cached values from the original request
+      env.delete_if { |k, _| k =~ /^(action_dispatch|rack)\.request/ }
+      env.delete_if { |k, _| k =~ /^action_dispatch\.rescue/ }
+      env['rack.input'] = StringIO.new
+      env.delete 'CONTENT_LENGTH'
+      env.delete 'RAW_POST_DATA'
     end
   end
 end


### PR DESCRIPTION
Fixes issue raised in #40 

The original request env was adding cached parameters resulting in the cover page requests using the cache instead of generating the params themselves. This change scrubs the env before calling to the app when generating the cover page. The method used was pulled out of the ActionController TestCase class so should give us reasonable expectations over what needs to be cleaned up between requests. 