### PR TITLE
Viewport Override (for dynamic width/height) and Rspec tests compatibility with imagemagick7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Gemfile.lock
 package-lock.json
 /node_modules
 /coverage
+spec/examples.txt

--- a/lib/grover.rb
+++ b/lib/grover.rb
@@ -86,7 +86,7 @@ class Grover
 
             // Setup viewport options (if provided)
             const viewport = options.viewport; delete options.viewport;
-            if (viewport != undefined) {
+            if (viewport != undefined && (viewport.width != undefined && viewport.height != undefined)) {
               await page.setViewport(viewport);
             }
 
@@ -123,6 +123,17 @@ class Grover
             const executeScript = options.executeScript; delete options.executeScript;
             if (executeScript != undefined) {
               await page.evaluate(executeScript);
+            }
+
+            // Override viewport with document body offsetHeight & offsetWidth, if viewport object is provided and the width or height isn't specified.
+            if (viewport != undefined && (viewport.width == undefined || viewport.height == undefined)) {
+              let vport = {};
+              vport['height'] = await page.evaluate(() => document.body.offsetHeight)
+              vport['width'] = await page.evaluate(() => document.body.offsetWidth)
+              if(viewport.width != undefined) { vport['width'] = viewport.width }
+              if(viewport.height != undefined) { vport['height'] = viewport.height }
+              const override = Object.assign(page.viewport(), vport);
+              await page.setViewport(override);
             }
 
             // If we're running puppeteer in headless mode, return the converted PDF

--- a/lib/grover.rb
+++ b/lib/grover.rb
@@ -84,9 +84,9 @@ class Grover
               request_options.timeout = timeout;
             }
 
-            // Setup viewport options (if provided)
+            // Setup viewport options (ONLY if width and height are provided)
             const viewport = options.viewport; delete options.viewport;
-            if (viewport != undefined && (viewport.width != undefined && viewport.height != undefined)) {
+            if (viewport != undefined && viewport.width && viewport.height) {
               await page.setViewport(viewport);
             }
 
@@ -125,13 +125,14 @@ class Grover
               await page.evaluate(executeScript);
             }
 
-            // Override viewport with document body offsetHeight & offsetWidth, if viewport object is provided and the width or height isn't specified.
+            // Override viewport with document body offsetHeight or offsetWidth, if viewport object is provided and the width or height isn't specified.
+            // This will auto adjust the viewport to the document body size. Very useful in a situation where by only the viewport width or height is known
             if (viewport != undefined && (viewport.width == undefined || viewport.height == undefined)) {
               let vport = {};
               vport['height'] = await page.evaluate(() => document.body.offsetHeight)
               vport['width'] = await page.evaluate(() => document.body.offsetWidth)
-              if(viewport.width != undefined) { vport['width'] = viewport.width }
-              if(viewport.height != undefined) { vport['height'] = viewport.height }
+              if(viewport.width) { vport['width'] = viewport.width }
+              if(viewport.height) { vport['height'] = viewport.height }
               const override = Object.assign(page.viewport(), vport);
               await page.setViewport(override);
             }

--- a/lib/grover/version.rb
+++ b/lib/grover/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Grover
-  VERSION = '0.11.5'
+  VERSION = '0.11.6'
 end

--- a/lib/grover/version.rb
+++ b/lib/grover/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Grover
-  VERSION = '0.11.4'
+  VERSION = '0.11.5'
 end

--- a/spec/grover_spec.rb
+++ b/spec/grover_spec.rb
@@ -391,6 +391,14 @@ describe Grover do
 
     let(:image) { MiniMagick::Image.read screenshot }
 
+    shared_examples 'it adjusts unspecified viewport dimension to document body offset dimension' do
+      it { expect(screenshot.unpack('C*')).to start_with "\x89PNG\r\n\x1A\n".unpack('C*') }
+      it { expect(image.type).to eq 'PNG' }
+      # The viewport should adjust to match the document body width
+      it { expect(image.dimensions).to eq [400, 200] }
+      it { expect(mean_colour_statistics(image)).to eq %w[165 42 42] }
+    end
+
     context 'when passing through a valid URL' do
       let(:url_or_html) { 'https://media.gettyimages.com/photos/tabby-cat-selfie-picture-id1151094724?s=2048x2048' }
 
@@ -443,22 +451,14 @@ describe Grover do
         let(:url_or_html) { '<html><body style="background-color: brown;height: 200px;"></body></html>' }
         let(:options) { { viewport: { width: 400 } } }
 
-        it { expect(screenshot.unpack('C*')).to start_with "\x89PNG\r\n\x1A\n".unpack('C*') }
-        it { expect(image.type).to eq 'PNG' }
-        # The viewport should adjust to match the document body height
-        it { expect(image.dimensions).to eq [400, 200] }
-        it { expect(mean_colour_statistics(image)).to eq %w[165 42 42] }
+        it_behaves_like 'it adjusts unspecified viewport dimension to document body offset dimension'
       end
 
       context 'with only height' do
         let(:url_or_html) { '<html><body style="background-color: brown;width: 400px;"></body></html>' }
         let(:options) { { viewport: { height: 200 } } }
 
-        it { expect(screenshot.unpack('C*')).to start_with "\x89PNG\r\n\x1A\n".unpack('C*') }
-        it { expect(image.type).to eq 'PNG' }
-        # The viewport should adjust to match the document body width
-        it { expect(image.dimensions).to eq [400, 200] }
-        it { expect(mean_colour_statistics(image)).to eq %w[165 42 42] }
+        it_behaves_like 'it adjusts unspecified viewport dimension to document body offset dimension'
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ require 'mini_magick'
 
 RSpec.configure do |config|
   config.order = 'random'
+  config.example_status_persistence_file_path = './spec/examples.txt'
 
   include Rack::Test::Methods
 end


### PR DESCRIPTION
Firstly, Thank you for this life saving gem!

I had to fork this gem for my personal use based on the following reasons:

- **Currently**, to use the viewport option you must pass both width and height parameter. But in my case, the required image width is known (for a Till printer) but the height varies.

**Changes made:**

- [x] Added a Javascript function to use the given viewport dimension (width or height) and then override the viewport dimension not specified with the document body offset dimension. 
- [x] Rspec tests for dynamic width and height scenarios
- [x] Rspec tests for compatibility with imagemagick7

I hope this will be useful for someone in need.