### PR TITLE
Update specs to support ImageMagick 7

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,15 @@ Layout/DotPosition:
 Layout/LineLength:
   Max: 120
 
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
 Metrics/BlockLength:
   Exclude:
     - "**/*_spec.rb"
@@ -25,3 +34,15 @@ RSpec/NestedGroups:
 Style/Documentation:
   Exclude:
     - "lib/active_support_ext/**/*.rb"
+
+Style/ExponentialNotation:
+  Enabled: true
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env:
   jobs:
     - PUPPETEER_VERSION=1.20.0
     - PUPPETEER_VERSION=2.1.1
+    - PUPPETEER_VERSION=3.0.4
 
 language: ruby
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ rvm:
   - 2.5
   - 2.6
 
+node_js:
+  - 10
+
 before_install:
   - gem update bundler
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,8 @@ rvm:
   - 2.5
   - 2.6
 
-node_js:
-  - 10
-
 before_install:
+  - nvm install 10
   - gem update bundler
 
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## Unreleased
-- None
+### Fixed
+- [#52](https://github.com/Studiosity/grover/pull/52) Fix specs to work with ImageMagick 7 ([@inspiredstuffs][])
 
 ## [0.11.4](releases/tag/v0.11.4) - 2020-04-25
 ### Added
@@ -195,3 +196,4 @@
 [@jnimety]: https://github.com/jnimety
 [@willkoehler]: https://github.com/willkoehler
 [@Richacinas]: https://github.com/Richacinas
+[@inspiredstuffs]: https://github.com/inspiredstuffs 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   },
   "homepage": "https://github.com/Studiosity/grover#readme",
   "devDependencies": {
-    "puppeteer": "^2.1.1"
+    "puppeteer": "^3.0.4"
   }
 }

--- a/spec/grover_spec.rb
+++ b/spec/grover_spec.rb
@@ -402,7 +402,7 @@ describe Grover do
       # don't really want to rely on pixel testing the website screenshot
       # so we'll check it's mean colour is roughly what we expect
       it do
-        expect(image.data.dig('imageStatistics', 'all', 'mean').to_f).
+        expect(image.data.dig('imageStatistics', MiniMagick.imagemagick7? ? 'Overall' : 'all', 'mean').to_f).
           to be_within(1).of(97.7473).  # ImageMagick 6.9.3-1 (version used by Travis CI)
           or be_within(1).of(161.497)   # ImageMagick 6.9.10-84
       end
@@ -609,6 +609,8 @@ describe Grover do
   end
 
   def mean_colour_statistics(image)
-    %w[red green blue].map { |colour| image.data.dig('channelStatistics', colour, 'mean').to_s }
+    colours = %w[red green blue]
+    colours = colours.map(&:capitalize) if MiniMagick.imagemagick7?
+    colours.map { |colour| image.data.dig('channelStatistics', colour, 'mean').to_s }
   end
 end


### PR DESCRIPTION
Update specs to support ImageMagick 7
Update Rubocop config to support latest cops
Include Puppeteer 3.x in CI build matrix
Bump minimum NodeJS version from CI default (8) to 10 - needed for Puppeteer 3.x
