### PR TITLE
Remove Schmooze in favour of built in fork

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,9 @@ Lint/RaiseException:
 Lint/StructNewOverride:
   Enabled: true
 
+Metrics/AbcSize:
+    Max: 20
+
 Metrics/BlockLength:
   Exclude:
     - "**/*_spec.rb"
@@ -28,8 +31,11 @@ RSpec/ExampleLength:
 RSpec/MessageSpies:
   EnforcedStyle: receive
 
+RSpec/MultipleExpectations:
+  Max: 4
+
 RSpec/NestedGroups:
-  Max: 5
+  Max: 6
 
 Style/Documentation:
   Exclude:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Travis Build Status](https://img.shields.io/travis/Studiosity/grover.svg?style=flat)](https://travis-ci.org/Studiosity/grover)
+[![Travis Build Status](https://img.shields.io/travis/Studiosity/grover/master.svg?style=flat)](https://travis-ci.org/Studiosity/grover)
 [![Maintainability](https://api.codeclimate.com/v1/badges/37609653789bcf2c8d94/maintainability)](https://codeclimate.com/github/Studiosity/grover/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/37609653789bcf2c8d94/test_coverage)](https://codeclimate.com/github/Studiosity/grover/test_coverage)
 [![Gem Version](https://badge.fury.io/rb/grover.svg)](https://badge.fury.io/rb/grover)
@@ -334,6 +334,9 @@ both succeed
 Thanks are given to the great work done in the [PDFKit project](https://github.com/pdfkit/pdfkit).
 The middleware and HTML preprocessing components were used heavily in the implementation of Grover.
 
+Thanks are also given to the excellent [Schmooze project](https://github.com/Shopify/schmooze).
+The Ruby to NodeJS interface in Grover is heavily based off that work. Grover previously used that gem,
+however migrated away due to differing requirements over persistence/cleanup of the NodeJS worker process.  
 
 ## License
 

--- a/grover.gemspec
+++ b/grover.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'combine_pdf', '~> 1.0'
   spec.add_dependency 'nokogiri', '~> 1.0'
-  spec.add_dependency 'schmooze', '~> 0.2'
 
   spec.add_development_dependency 'mini_magick', '~> 4.9'
   spec.add_development_dependency 'pdf-reader', '~> 2.2'

--- a/lib/grover.rb
+++ b/lib/grover.rb
@@ -5,144 +5,20 @@ require 'grover/version'
 require 'grover/utils'
 require 'active_support_ext/object/deep_dup' unless defined?(ActiveSupport)
 
+require 'grover/errors'
 require 'grover/html_preprocessor'
 require 'grover/middleware'
 require 'grover/configuration'
 require 'grover/options_builder'
+require 'grover/processor'
 
 require 'nokogiri'
-require 'schmooze'
 require 'yaml'
 
 #
 # Grover interface for converting HTML to PDF
 #
 class Grover
-  #
-  # Processor helper class for calling out to Puppeteer NodeJS library
-  #
-  class Processor < Schmooze::Base
-    dependencies puppeteer: 'puppeteer'
-
-    def self.launch_params
-      ENV['GROVER_NO_SANDBOX'] == 'true' ? "{args: ['--no-sandbox', '--disable-setuid-sandbox']}" : '{args: []}'
-    end
-
-    def self.convert_function(convert_action)
-      <<~FUNCTION
-        async (url_or_html, options) => {
-          let browser;
-          try {
-            let launchParams = #{launch_params};
-
-            // Configure puppeteer debugging options
-            const debug = options.debug; delete options.debug;
-            if (typeof debug === 'object' && !!debug) {
-              if (debug.headless != undefined) { launchParams.headless = debug.headless; }
-              if (debug.devtools != undefined) { launchParams.devtools = debug.devtools; }
-            }
-
-            // Configure additional launch arguments
-            const args = options.launchArgs; delete options.launchArgs;
-            if (Array.isArray(args)) {
-              launchParams.args = launchParams.args.concat(args);
-            }
-
-            // Set executable path if given
-            const executablePath = options.executablePath; delete options.executablePath;
-            if (executablePath) {
-              launchParams.executablePath = executablePath;
-            }
-
-            // Launch the browser and create a page
-            browser = await puppeteer.launch(launchParams);
-            const page = await browser.newPage();
-
-            // Basic auth
-            const username = options.username; delete options.username
-            const password = options.password; delete options.password
-            if (username != undefined && password != undefined) {
-              await page.authenticate({ username, password });
-            }
-
-            // Setting cookies
-            const cookies = options.cookies; delete options.cookies
-            if (Array.isArray(cookies)) {
-              await page.setCookie(...cookies);
-            }
-
-            // Set caching flag (if provided)
-            const cache = options.cache; delete options.cache;
-            if (cache != undefined) {
-              await page.setCacheEnabled(cache);
-            }
-
-            // Setup timeout option (if provided)
-            let request_options = {};
-            const timeout = options.timeout; delete options.timeout;
-            if (timeout != undefined) {
-              request_options.timeout = timeout;
-            }
-
-            // Setup viewport options (if provided)
-            const viewport = options.viewport; delete options.viewport;
-            if (viewport != undefined) {
-              await page.setViewport(viewport);
-            }
-
-            const waitUntil = options.waitUntil; delete options.waitUntil;
-            if (url_or_html.match(/^http/i)) {
-              // Request is for a URL, so request it
-              request_options.waitUntil = waitUntil || 'networkidle2';
-              await page.goto(url_or_html, request_options);
-            } else {
-              // Request is some HTML content. Use request interception to assign the body
-              request_options.waitUntil = waitUntil || 'networkidle0';
-              await page.setRequestInterception(true);
-              page.once('request', request => {
-                request.respond({ body: url_or_html });
-                // Reset the request interception
-                // (we only want to intercept the first request - ie our HTML)
-                page.on('request', request => request.continue());
-              });
-              const displayUrl = options.displayUrl; delete options.displayUrl;
-              await page.goto(displayUrl || 'http://example.com', request_options);
-            }
-
-            // If specified, emulate the media type
-            const emulateMedia = options.emulateMedia; delete options.emulateMedia;
-            if (emulateMedia != undefined) {
-              if (typeof page.emulateMediaType == 'function') {
-                await page.emulateMediaType(emulateMedia);
-              } else {
-                await page.emulateMedia(emulateMedia);
-              }
-            }
-
-            // If specified, evaluate script on the page
-            const executeScript = options.executeScript; delete options.executeScript;
-            if (executeScript != undefined) {
-              await page.evaluate(executeScript);
-            }
-
-            // If we're running puppeteer in headless mode, return the converted PDF
-            if (debug == undefined || (typeof debug === 'object' && (debug.headless == undefined || debug.headless))) {
-              return await page.#{convert_action}(options);
-            }
-          } finally {
-            if (browser) {
-              await browser.close();
-            }
-          }
-        }
-      FUNCTION
-    end
-
-    method :convert_pdf, convert_function('pdf')
-    method :convert_screenshot, convert_function('screenshot')
-  end
-  private_constant :Processor
-
   DEFAULT_HEADER_TEMPLATE = "<div class='date text left'></div><div class='title text center'></div>"
   DEFAULT_FOOTER_TEMPLATE = <<~HTML
     <div class='url text left grow'></div>
@@ -171,10 +47,7 @@ class Grover
   # @return [String] The resulting PDF data
   #
   def to_pdf(path = nil)
-    result = processor.convert_pdf @url, normalized_options(path: path)
-    return unless result
-
-    result['data'].pack('C*')
+    processor.convert :pdf, @url, normalized_options(path: path)
   end
 
   #
@@ -186,11 +59,8 @@ class Grover
   #
   def screenshot(path: nil, format: nil)
     options = normalized_options(path: path)
-    options['type'] = format if format.is_a? ::String
-    result = processor.convert_screenshot @url, options
-    return unless result
-
-    result['data'].pack('C*')
+    options['type'] = format if %w[png jpeg].include? format
+    processor.convert :screenshot, @url, options
   end
 
   #
@@ -200,7 +70,7 @@ class Grover
   # @return [String] The resulting PNG data
   #
   def to_png(path = nil)
-    screenshot(path: path, format: 'png')
+    screenshot path: path, format: 'png'
   end
 
   #
@@ -210,7 +80,7 @@ class Grover
   # @return [String] The resulting JPEG data
   #
   def to_jpeg(path = nil)
-    screenshot(path: path, format: 'jpeg')
+    screenshot path: path, format: 'jpeg'
   end
 
   #

--- a/lib/grover/errors.rb
+++ b/lib/grover/errors.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Grover
+  #
+  # Error classes for calling out to Puppeteer NodeJS library
+  #
+  # Heavily based on the Schmooze library https://github.com/Shopify/schmooze
+  #
+  Error = Class.new(StandardError)
+  DependencyError = Class.new(Error)
+  module JavaScript # rubocop:disable Style/Documentation
+    Error = Class.new(::Grover::Error)
+    UnknownError = Class.new(Error)
+    def self.const_missing(name)
+      const_set name, Class.new(Error)
+    end
+  end
+end

--- a/lib/grover/js/processor.js
+++ b/lib/grover/js/processor.js
@@ -1,0 +1,147 @@
+// Setup imports
+try {
+  const Module = require('module');
+  // resolve puppeteer from the CWD instead of where this script is located
+  var puppeteer = require(require.resolve('puppeteer', { paths: Module._nodeModulePaths(process.cwd()) }));
+} catch (e) {
+  process.stdout.write(JSON.stringify(['err', e.toString()]));
+  process.stdout.write("\n");
+  process.exit(1);
+}
+process.stdout.write("[\"ok\"]\n");
+
+const _processPage = (async (convertAction, urlOrHtml, options) => {
+  let browser;
+  try {
+    const launchParams = {
+      args: process.env.GROVER_NO_SANDBOX === 'true' ? ['--no-sandbox', '--disable-setuid-sandbox'] : []
+    };
+
+    // Configure puppeteer debugging options
+    const debug = options.debug; delete options.debug;
+    if (typeof debug === 'object' && !!debug) {
+      if (debug.headless !== undefined) { launchParams.headless = debug.headless; }
+      if (debug.devtools !== undefined) { launchParams.devtools = debug.devtools; }
+    }
+
+    // Configure additional launch arguments
+    const args = options.launchArgs; delete options.launchArgs;
+    if (Array.isArray(args)) {
+      launchParams.args = launchParams.args.concat(args);
+    }
+
+    // Set executable path if given
+    const executablePath = options.executablePath; delete options.executablePath;
+    if (executablePath) {
+      launchParams.executablePath = executablePath;
+    }
+
+    // Launch the browser and create a page
+    browser = await puppeteer.launch(launchParams);
+    const page = await browser.newPage();
+
+    // Basic auth
+    const username = options.username; delete options.username
+    const password = options.password; delete options.password
+    if (username !== undefined && password !== undefined) {
+      await page.authenticate({ username, password });
+    }
+
+    // Setting cookies
+    const cookies = options.cookies; delete options.cookies
+    if (Array.isArray(cookies)) {
+      await page.setCookie(...cookies);
+    }
+
+    // Set caching flag (if provided)
+    const cache = options.cache; delete options.cache;
+    if (cache !== undefined) {
+      await page.setCacheEnabled(cache);
+    }
+
+    // Setup timeout option (if provided)
+    let requestOptions = {};
+    const timeout = options.timeout; delete options.timeout;
+    if (timeout !== undefined) {
+      requestOptions.timeout = timeout;
+    }
+
+    // Setup viewport options (if provided)
+    const viewport = options.viewport; delete options.viewport;
+    if (viewport !== undefined) {
+      await page.setViewport(viewport);
+    }
+
+    const waitUntil = options.waitUntil; delete options.waitUntil;
+    if (urlOrHtml.match(/^http/i)) {
+      // Request is for a URL, so request it
+      requestOptions.waitUntil = waitUntil || 'networkidle2';
+      await page.goto(urlOrHtml, requestOptions);
+    } else {
+      // Request is some HTML content. Use request interception to assign the body
+      requestOptions.waitUntil = waitUntil || 'networkidle0';
+      await page.setRequestInterception(true);
+      page.once('request', request => {
+        request.respond({ body: urlOrHtml });
+        // Reset the request interception
+        // (we only want to intercept the first request - ie our HTML)
+        page.on('request', request => request.continue());
+      });
+      const displayUrl = options.displayUrl; delete options.displayUrl;
+      await page.goto(displayUrl || 'http://example.com', requestOptions);
+    }
+
+    // If specified, emulate the media type
+    const emulateMedia = options.emulateMedia; delete options.emulateMedia;
+    if (emulateMedia !== undefined) {
+      if (typeof page.emulateMediaType == 'function') {
+        await page.emulateMediaType(emulateMedia);
+      } else {
+        await page.emulateMedia(emulateMedia);
+      }
+    }
+
+    // If specified, evaluate script on the page
+    const executeScript = options.executeScript; delete options.executeScript;
+    if (executeScript !== undefined) {
+      await page.evaluate(executeScript);
+    }
+
+    // If we're running puppeteer in headless mode, return the converted PDF
+    if (debug === undefined || (typeof debug === 'object' && (debug.headless === undefined || debug.headless))) {
+      return await page[convertAction](options);
+    }
+  } finally {
+    if (browser) {
+      await browser.close();
+    }
+  }
+});
+
+function _handleError(error) {
+  if (error instanceof Error) {
+    process.stdout.write(
+      JSON.stringify(['err', error.toString().replace(new RegExp('^' + error.name + ': '), ''), error.name])
+    );
+  } else {
+    process.stdout.write(JSON.stringify(['err', error.toString()]));
+  }
+  process.stdout.write("\n");
+}
+
+// Interface for communicating between Ruby processor and Node processor
+require('readline').createInterface({
+  input: process.stdin,
+  terminal: false,
+}).on('line', function(line) {
+  try {
+    Promise.resolve(_processPage.apply(null, JSON.parse(line)))
+      .then(function (result) {
+        process.stdout.write(JSON.stringify(['ok', result]));
+        process.stdout.write("\n");
+      })
+      .catch(_handleError);
+  } catch(error) {
+    _handleError(error);
+  }
+});

--- a/lib/grover/processor.rb
+++ b/lib/grover/processor.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'open3'
+
+class Grover
+  #
+  # Processor helper class for calling out to Puppeteer NodeJS library
+  #
+  # Heavily based on the Schmooze library https://github.com/Shopify/schmooze
+  #
+  class Processor
+    def initialize(app_root)
+      @app_root = app_root
+    end
+
+    def convert(method, url_or_html, options)
+      spawn_process
+      ensure_packages_are_initiated
+      result = call_js_method method, url_or_html, options
+      return unless result
+
+      result['data'].pack('C*')
+    ensure
+      cleanup_process
+    end
+
+    private
+
+    attr_reader :app_root, :stdin, :stdout, :stderr, :wait_thr
+
+    def spawn_process
+      @stdin, @stdout, @stderr, @wait_thr = Open3.popen3(
+        'node',
+        File.expand_path(File.join(__dir__, 'js/processor.js')),
+        chdir: app_root
+      )
+    end
+
+    def ensure_packages_are_initiated
+      input = stdout.gets
+      raise Grover::Error, "Failed to instantiate worker process:\n#{stderr.read}" if input.nil?
+
+      result = JSON.parse(input)
+      return if result[0] == 'ok'
+
+      cleanup_process
+      parse_package_error result[1]
+    end
+
+    def parse_package_error(error_message) # rubocop:disable Metrics/MethodLength
+      package_name = error_message[/^Error: Cannot find module '(.*)'$/, 1]
+      raise Grover::Error, error_message unless package_name
+
+      begin
+        %w[dependencies devDependencies].each do |key|
+          next unless package_json.key?(key) && package_json[key].key?(package_name)
+
+          raise Grover::DependencyError, Utils.squish(<<~ERROR)
+            Cannot find module '#{package_name}'.
+            The module was found in '#{package_json_path}' however, please run 'npm install' from '#{app_root}'
+          ERROR
+        end
+      rescue Errno::ENOENT # rubocop:disable Lint/SuppressedException
+      end
+      raise Grover::DependencyError, Utils.squish(<<~ERROR)
+        Cannot find module '#{package_name}'. You need to add it to '#{package_json_path}' and run 'npm install'
+      ERROR
+    end
+
+    def package_json_path
+      @package_json_path ||= File.join(app_root, 'package.json')
+    end
+
+    def package_json
+      @package_json ||= JSON.parse(File.read(package_json_path))
+    end
+
+    def call_js_method(method, url_or_html, options) # rubocop:disable Metrics/MethodLength
+      stdin.puts JSON.dump([method, url_or_html, options])
+      input = stdout.gets
+      raise Errno::EPIPE, "Can't read from worker" if input.nil?
+
+      status, message, error_class = JSON.parse(input)
+
+      if status == 'ok'
+        message
+      elsif error_class.nil?
+        raise Grover::JavaScript::UnknownError, message
+      else
+        raise Grover::JavaScript.const_get(error_class, false), message
+      end
+    rescue Errno::EPIPE, IOError
+      raise Grover::Error, "Worker process failed:\n#{stderr.read}"
+    end
+
+    def cleanup_process
+      stdin.close
+      stdout.close
+      stderr.close
+      wait_thr.join
+    end
+  end
+end

--- a/spec/active_support_ext/object/deep_dup_spec.rb
+++ b/spec/active_support_ext/object/deep_dup_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'DeepDup' do
+  describe 'Object' do
+    it 'deep duplicates objects' do
+      object = Object.new
+      dup = object.deep_dup
+      dup.instance_variable_set(:@a, 1)
+      expect(object.instance_variable_defined?(:@a)).to eq false
+      expect(dup.instance_variable_defined?(:@a)).to eq true
+    end
+  end
+
+  describe 'Array' do
+    it 'deep duplicates arrays' do
+      array = [1, [2, 3]]
+      dup = array.deep_dup
+      dup[1][2] = 4
+      expect(array[1][2]).to be_nil
+      expect(dup[1][2]).to eq 4
+    end
+
+    it 'deep duplicates arrays with hash inside' do
+      array = [1, { a: 2, b: 3 }]
+      dup = array.deep_dup
+      dup[1][:c] = 4
+      expect(array[1][:c]).to be_nil
+      expect(dup[1][:c]).to eq 4
+    end
+  end
+
+  describe 'Hash' do
+    it 'deep duplicates hashes' do
+      hash = { a: { b: 'b' } }
+      dup = hash.deep_dup
+      dup[:a][:c] = 'c'
+      expect(hash[:a][:c]).to be_nil
+      expect(dup[:a][:c]).to eq 'c'
+    end
+
+    it 'deep duplicates hashes with arrays inside' do
+      hash = { a: [1, 2] }
+      dup = hash.deep_dup
+      dup[:a][2] = 'c'
+      expect(hash[:a][2]).to be_nil
+      expect(dup[:a][2]).to eq 'c'
+    end
+
+    it 'deep duplicates hash initialisation' do
+      zero_hash = Hash.new 0
+      hash = { a: zero_hash }
+      dup = hash.deep_dup
+      expect(dup[:a][44]).to eq 0
+    end
+
+    it 'deep duplicates hashes with string key' do
+      hash = { 'a' => { b: 'b' } }
+      dup = hash.deep_dup
+      dup['a'][:c] = 'c'
+      expect(hash['a'][:c]).to be_nil
+      expect(dup['a'][:c]).to eq 'c'
+    end
+
+    it 'deep duplicates hash with class key' do
+      hash = { Integer => 1 }
+      dup = hash.deep_dup
+      expect(dup.keys.length).to eq 1
+    end
+  end
+end

--- a/spec/grover/errors_spec.rb
+++ b/spec/grover/errors_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Grover::Error do
+  it { is_expected.to be_a StandardError }
+
+  describe 'Grover::DependencyError' do
+    subject { Grover::DependencyError.new }
+
+    it { is_expected.to be_a described_class }
+  end
+
+  describe 'Grover::JavaScript::Error' do
+    subject { Grover::JavaScript::Error.new }
+
+    it { is_expected.to be_a described_class }
+  end
+
+  describe 'Grover::JavaScript::UnknownError' do
+    subject { Grover::JavaScript::UnknownError.new }
+
+    it { is_expected.to be_a Grover::JavaScript::Error }
+  end
+
+  describe 'Grover::JavaScript::SomeOtherError' do
+    subject { Grover::JavaScript::SomeOtherError.new }
+
+    it { is_expected.to be_a Grover::JavaScript::Error }
+  end
+end

--- a/spec/grover/middleware_spec.rb
+++ b/spec/grover/middleware_spec.rb
@@ -33,7 +33,6 @@ describe Grover::Middleware do
     @env # rubocop:disable RSpec/InstanceVariable
   end
 
-  # rubocop:disable RSpec/MultipleExpectations
   describe '#call' do
     describe 'response content type' do
       context 'when requesting a PDF' do
@@ -777,5 +776,4 @@ describe Grover::Middleware do
       end
     end
   end
-  # rubocop:enable RSpec/MultipleExpectations
 end

--- a/spec/grover/processor_spec.rb
+++ b/spec/grover/processor_spec.rb
@@ -1,0 +1,476 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Grover::Processor do
+  subject(:processor) { described_class.new Dir.pwd }
+
+  describe '#convert' do
+    subject(:convert) { processor.convert method, url_or_html, options }
+
+    let(:url_or_html) { 'http://google.com' }
+    let(:options) { {} }
+
+    context 'when converting to PDF' do
+      let(:method) { :pdf }
+
+      let(:pdf_reader) { PDF::Reader.new pdf_io }
+      let(:pdf_io) { StringIO.new convert }
+      let(:pdf_text_content) { Grover::Utils.squish(pdf_reader.pages.first.text) }
+      let(:large_text) { '<style>.text { font-size: 14px; }</style>' }
+      let(:default_header) { Grover::DEFAULT_HEADER_TEMPLATE }
+      let(:basic_header_footer_options) do
+        {
+          'displayHeaderFooter' => true,
+          'displayUrl' => 'http://www.example.net/foo/bar',
+          'margin' => {
+            'top' => '1in',
+            'bottom' => '1in'
+          }
+        }
+      end
+
+      it 'cleans up the worker process' do
+        expect { convert }.not_to(change { `ps | grep node | grep -v 'grep node' | wc -l` })
+      end
+
+      context 'when passing through a valid URL' do
+        # we need to add the language for test stability
+        # if not added explicitly, google can respond with a different locale
+        # based on IP address geo-lookup, timezone, etc.
+        let(:url_or_html) { 'https://www.google.com/?gl=us' }
+
+        it { is_expected.to start_with "%PDF-1.4\n" }
+        it { expect(pdf_reader.page_count).to eq 1 }
+        it { expect(pdf_text_content).to include "I'm Feeling Lucky" }
+      end
+
+      context 'when passing through an invalid URL' do
+        let(:url_or_html) { 'https://fake.invalid' }
+
+        it 'raises a JavaScript error warning that the URL could not be resolved' do
+          expect do
+            convert
+          end.to raise_error Grover::JavaScript::Error, %r{net::ERR_NAME_NOT_RESOLVED at https://fake.invalid}
+        end
+      end
+
+      context 'when puppeteer package is not installed' do
+        # Temporarily move the node puppeteer folder
+        before { FileUtils.move 'node_modules/puppeteer', 'node_modules/puppeteer_temp' }
+
+        after { FileUtils.move 'node_modules/puppeteer_temp', 'node_modules/puppeteer' }
+
+        it 'raises a DependencyError' do
+          expect { convert }.to raise_error Grover::DependencyError, Grover::Utils.squish(<<~ERROR)
+            Cannot find module 'puppeteer'.
+            The module was found in '#{Dir.pwd}/package.json' however, please run 'npm install' from '#{Dir.pwd}'
+          ERROR
+        end
+
+        context 'when puppeteer package is not in package.json' do
+          before do
+            FileUtils.copy 'package.json', 'package.json.tmp'
+            IO.write('package.json', File.open('package.json') { |f| f.read.gsub(/"puppeteer"/, '"puppeteer-tmp"') })
+          end
+
+          after { FileUtils.move 'package.json.tmp', 'package.json' }
+
+          it 'raises a DependencyError' do
+            expect { convert }.to raise_error Grover::DependencyError, Grover::Utils.squish(<<~ERROR)
+              Cannot find module 'puppeteer'.
+              You need to add it to '#{Dir.pwd}/package.json' and run 'npm install'
+            ERROR
+          end
+        end
+      end
+
+      context 'when stubbing the call to the Node processor' do
+        let(:stdin) { instance_double 'IO' }
+        let(:stdout) { instance_double 'IO' }
+        let(:stderr) { instance_double 'IO' }
+        let(:wait_thr) { instance_double 'Process::Waiter' }
+
+        before do
+          allow(Open3).to(
+            receive(:popen3).
+              with('node', File.expand_path(File.join(__dir__, '../../lib/grover/js/processor.js')), chdir: Dir.pwd).
+              and_return([stdin, stdout, stderr, wait_thr])
+          )
+
+          allow(stdin).to receive(:close)
+          allow(stdout).to receive(:close)
+          allow(stderr).to receive(:close)
+          allow(wait_thr).to receive(:join)
+        end
+
+        context 'when first call to gets on stdout returns nil' do
+          before do
+            allow(stdout).to receive(:gets).and_return nil
+            allow(stderr).to receive(:read).and_return 'The reason the worker failed'
+          end
+
+          it 'raises an Error' do
+            expect { convert }.to raise_error Grover::Error, <<~ERROR.strip
+              Failed to instantiate worker process:
+              The reason the worker failed
+            ERROR
+          end
+        end
+
+        context 'when first call to gets on stdout succeeds but second returns nil' do
+          before do
+            allow(stdout).to receive(:gets).and_return '["ok"]', nil
+            allow(stdin).to receive(:puts).with '["pdf","http://google.com",{}]'
+            allow(stderr).to receive(:read).and_return 'The reason the worker failed'
+          end
+
+          it 'raises an Error' do
+            expect { convert }.to raise_error Grover::Error, <<~ERROR.strip
+              Worker process failed:
+              The reason the worker failed
+            ERROR
+          end
+        end
+
+        context 'when first call to gets on stdout succeeds but second returns an error' do
+          before do
+            allow(stdout).to receive(:gets).and_return '["ok"]', '["err","Some unknown thing happened"]'
+            allow(stdin).to receive(:puts).with '["pdf","http://google.com",{}]'
+            allow(stderr).to receive(:read).and_return 'The reason the worker failed'
+          end
+
+          it 'raises a JavaScript UnknownError' do
+            expect { convert }.to raise_error Grover::JavaScript::UnknownError, 'Some unknown thing happened'
+          end
+        end
+      end
+
+      context 'when passing through html' do
+        let(:url_or_html) { '<html><body><h1>Hey there</h1></body></html>' }
+
+        it { is_expected.to start_with "%PDF-1.4\n" }
+        it { expect(pdf_reader.page_count).to eq 1 }
+        it { expect(pdf_text_content).to eq 'Hey there' }
+      end
+
+      context 'when passing through options to Grover' do
+        let(:url_or_html) { '<html><head><title>Paaage</title></head><body><h1>Hey there</h1></body></html>' }
+
+        context 'when options includes A4 page format' do
+          let(:options) { { format: 'A4' } }
+
+          it { expect(pdf_reader.pages.first.attributes).to include(MediaBox: [0, 0, 594.95996, 841.91998]) }
+        end
+
+        context 'when options includes Letter page format' do
+          let(:options) { { format: 'Letter' } }
+
+          it { expect(pdf_reader.pages.first.attributes).to include(MediaBox: [0, 0, 612, 792]) }
+        end
+
+        context 'when the page contains a line starting with `http`' do
+          let(:options) do
+            basic_header_footer_options.merge(
+              'headerTemplate' => large_text,
+              'footerTemplate' => "#{large_text}<div class='text'>Footer content</div>"
+            )
+          end
+          let(:url_or_html) do
+            <<~HTML
+              <html>
+                <body>
+                  <h1>Hey there</h1>
+              http://example.com
+                </body>
+              </html>
+            HTML
+          end
+
+          it { expect(pdf_text_content).to eq 'Hey there http://example.com Footer content' }
+        end
+
+        context 'when the options disable display of header/footer' do
+          let(:options) do
+            basic_header_footer_options.
+              merge('headerTemplate' => 'We dont expect to see this...', 'displayHeaderFooter' => false)
+          end
+
+          it { expect(pdf_text_content).to eq 'Hey there' }
+        end
+
+        context 'when the options include invalid values' do
+          let(:options) { basic_header_footer_options.merge('margin' => { 'top' => 'totes-invalid' }) }
+
+          it do
+            expect do
+              convert
+            end.to raise_error Grover::JavaScript::Error, /Failed to parse parameter value: totes-invalid/
+          end
+        end
+
+        context 'when options include header and footer enabled' do
+          let(:options) { basic_header_footer_options.merge('headerTemplate' => "#{large_text}#{default_header}") }
+
+          it do
+            date = Date.today.strftime '%-m/%-d/%Y'
+            expect(pdf_text_content).to eq "#{date} Paaage Hey there http://www.example.net/foo/bar 1/1"
+          end
+        end
+
+        context 'when options override header template' do
+          let(:options) do
+            basic_header_footer_options.merge('headerTemplate' => "#{large_text}<div class='text'>Excellente</div>")
+          end
+
+          it { expect(pdf_text_content).to eq 'Excellente Hey there http://www.example.net/foo/bar 1/1' }
+        end
+
+        context 'when header template includes the display url marker' do
+          let(:options) do
+            basic_header_footer_options.merge(
+              'headerTemplate' => "#{large_text}<div class='text'>abc<span class='url'></span>def</div>"
+            )
+          end
+
+          it do
+            expect(pdf_text_content).to(
+              eq('abchttp://www.example.net/foo/bardef Hey there http://www.example.net/foo/bar 1/1')
+            )
+          end
+        end
+
+        context 'when options override footer template' do
+          let(:options) { basic_header_footer_options.merge('footerTemplate' => footer_template) }
+          let(:footer_template) { "#{large_text}<div class='text'>great <span class='url'></span> page</div>" }
+
+          it do
+            date = Date.today.strftime '%-m/%-d/%Y'
+            expect(pdf_text_content).to eq "#{date} Paaage Hey there great http://www.example.net/foo/bar page"
+          end
+
+          context 'when template contains quotes' do
+            let(:footer_template) { %(<div class='text'>Footer with "quotes" in it</div>) }
+
+            it { expect(pdf_text_content).to include('Hey there Footer with "quotes" in it') }
+          end
+        end
+
+        context 'when displayUrl option is not provided' do
+          let(:options) { basic_header_footer_options.tap { |hash| hash.delete('displayUrl') } }
+
+          it 'uses the default `example.com` for the footer URL' do
+            date = Date.today.strftime '%-m/%-d/%Y'
+            expect(pdf_text_content).to eq "#{date} Paaage Hey there http://example.com/ 1/1"
+          end
+        end
+
+        context 'when passing through launch params' do
+          let(:options) { { 'launchArgs' => launch_args } }
+          let(:launch_args) { [] }
+          let(:url_or_html) do
+            <<-HTML
+              <html>
+                #{head}
+                <body>
+                  Speech recognition is <span id="test" />
+                  <script type="text/javascript">
+                    var speechSupported = "webkitSpeechRecognition" in window;
+                    document.getElementById("test").innerHTML = speechSupported ? "supported" : "not supported"
+                  </script>
+                </body>
+              </html>
+            HTML
+          end
+          let(:head) { '' }
+
+          it { expect(pdf_text_content).to eq 'Speech recognition is supported' }
+
+          context 'when launch params specify disabling the speech API' do
+            let(:launch_args) { ['--disable-speech-api'] }
+
+            it { expect(pdf_text_content).to eq 'Speech recognition is not supported' }
+          end
+        end
+
+        context 'when passing through waitUntil option' do
+          let(:url_or_html) do
+            <<-HTML
+              <html>
+                <body>
+                  Delayed JavaScript <span id="test">did not run</span>
+                  <script type="text/javascript">
+                    setTimeout(function() { document.getElementById("test").innerHTML = "ran"; }, 250);
+                  </script>
+                </body>
+              </html>
+            HTML
+          end
+
+          it { expect(pdf_text_content).to eq 'Delayed JavaScript ran' }
+
+          context 'when setting waitUntil option to load' do
+            let(:options) { { 'waitUntil' => 'load' } }
+
+            it { expect(pdf_text_content).to eq 'Delayed JavaScript did not run' }
+          end
+        end
+
+        context 'when options include executablePath' do
+          let(:options) { { 'executablePath' => '/totes/invalid/path' } }
+
+          it do
+            expect do
+              convert
+            end.to raise_error Grover::JavaScript::Error,
+                               %r{Failed to launch (chrome|the browser process)! spawn /totes/invalid/path}
+          end
+        end
+
+        context 'when requesting a URI requiring basic authentication' do
+          let(:url_or_html) { 'https://jigsaw.w3.org/HTTP/Basic/' }
+
+          it { expect(pdf_text_content).to eq 'Unauthorized access You are denied access to this resource.' }
+
+          context 'when passing through `username` and `password` options' do
+            let(:options) { { username: 'guest', password: 'guest' } }
+
+            it { expect(pdf_text_content).to eq 'Your browser made it!' }
+          end
+        end
+
+        context 'when passing through cookies option' do
+          let(:url_or_html) { 'https://cookie-renderer.herokuapp.com/' }
+          let(:options) do
+            {
+              'cookies' => [
+                { 'name' => 'grover-test', 'value' => 'nom nom nom', 'domain' => 'cookie-renderer.herokuapp.com' },
+                { 'name' => 'other-domain', 'value' => 'should not display', 'domain' => 'example.com' }
+              ]
+            }
+          end
+
+          it { expect(pdf_text_content).to include 'Request contained 1 cookie' }
+          it { expect(pdf_text_content).to include '1. grover-test nom nom nom' }
+        end
+      end
+
+      context 'when HTML includes screen only content' do
+        let(:url_or_html) do
+          <<-HTML
+            <html>
+              <head>
+                <style>
+                  @media not screen {
+                    .screen-only { display: none }
+                  }
+                </style>
+              </head>
+              <body>
+                <h1>Hey there</h1>
+                <div class="screen-only">This should only display for screen media</div>
+              </body>
+            </html>
+          HTML
+        end
+
+        it { expect(pdf_text_content).to eq 'Hey there' }
+
+        context 'with emulateMedia set to `screen`' do
+          let(:options) { { 'emulateMedia' => 'screen' } }
+
+          it { expect(pdf_text_content).to eq 'Hey there This should only display for screen media' }
+        end
+      end
+
+      context 'when evaluate option is specified' do
+        let(:url_or_html) { '<html><body></body></html>' }
+        let(:options) { basic_header_footer_options.merge('executeScript' => script) }
+        let(:script) { 'document.getElementsByTagName("body")[0].innerText = "Some evaluated content"' }
+        let(:date) { Date.today.strftime '%-m/%-d/%Y' }
+
+        it { expect(pdf_text_content).to eq "#{date} Some evaluated content http://www.example.net/foo/bar 1/1" }
+      end
+    end
+
+    context 'when converting to an image' do
+      let(:method) { :screenshot }
+
+      let(:image) { MiniMagick::Image.read convert }
+
+      context 'when passing through a valid URL' do
+        let(:url_or_html) { 'https://media.gettyimages.com/photos/tabby-cat-selfie-picture-id1151094724?s=2048x2048' }
+
+        # default screenshot is PNG 800w x 600h
+        it { expect(convert.unpack('C*')).to start_with "\x89PNG\r\n\x1A\n".unpack('C*') }
+        it { expect(image.type).to eq 'PNG' }
+        it { expect(image.dimensions).to eq [800, 600] }
+
+        # don't really want to rely on pixel testing the website screenshot
+        # so we'll check it's mean colour is roughly what we expect
+        it do
+          expect(image.data.dig('imageStatistics', MiniMagick.imagemagick7? ? 'Overall' : 'all', 'mean').to_f).
+            to be_within(1).of(97.7473).  # ImageMagick 6.9.3-1 (version used by Travis CI)
+            or be_within(1).of(161.497)   # ImageMagick 6.9.10-84
+        end
+      end
+
+      context 'when passing through html' do
+        let(:url_or_html) { '<html><body style="background-color: blue"></body></html>' }
+
+        it { expect(convert.unpack('C*')).to start_with "\x89PNG\r\n\x1A\n".unpack('C*') }
+        it { expect(image.type).to eq 'PNG' }
+        it { expect(image.dimensions).to eq [800, 600] }
+        it { expect(mean_colour_statistics(image)).to eq %w[0 0 255] }
+      end
+
+      context 'when passing through clip options to Grover' do
+        let(:url_or_html) { '<html><body style="background-color: red"></body></html>' }
+        let(:options) { { clip: { x: 0, y: 0, width: 200, height: 100 } } }
+
+        it { expect(convert.unpack('C*')).to start_with "\x89PNG\r\n\x1A\n".unpack('C*') }
+        it { expect(image.type).to eq 'PNG' }
+        it { expect(image.dimensions).to eq [200, 100] }
+        it { expect(mean_colour_statistics(image)).to eq %w[255 0 0] }
+      end
+
+      context 'when passing through viewport options to Grover' do
+        let(:url_or_html) { '<html><body style="background-color: brown"></body></html>' }
+        let(:options) { { viewport: { width: 400, height: 500 } } }
+
+        it { expect(convert.unpack('C*')).to start_with "\x89PNG\r\n\x1A\n".unpack('C*') }
+        it { expect(image.type).to eq 'PNG' }
+        it { expect(image.dimensions).to eq [400, 500] }
+        it { expect(mean_colour_statistics(image)).to eq %w[165 42 42] }
+      end
+
+      context 'when specifying type of `png`' do
+        let(:url_or_html) { '<html><body style="background-color: green"></body></html>' }
+        let(:options) { { type: 'png' } }
+
+        it { expect(convert.unpack('C*')).to start_with "\x89PNG\r\n\x1A\n".unpack('C*') }
+        it { expect(image.type).to eq 'PNG' }
+        it { expect(image.dimensions).to eq [800, 600] }
+        it { expect(mean_colour_statistics(image)).to eq %w[0 128 0] }
+      end
+
+      context 'when specifying type of `jpeg`' do
+        let(:url_or_html) { '<html><body style="background-color: purple"></body></html>' }
+        let(:options) { { type: 'jpeg' } }
+
+        it { expect(convert.unpack('C*')).to start_with [0xFF, 0xD8, 0xFF] }
+        it { expect(convert[6..9]).to eq 'JFIF' }
+        it { expect(convert.unpack('C*')).to end_with [0xFF, 0xD9] }
+        it { expect(image.type).to eq 'JPEG' }
+        it { expect(image.dimensions).to eq [800, 600] }
+        it { expect(mean_colour_statistics(image)).to eq %w[129 0 127] }
+      end
+
+      def mean_colour_statistics(image)
+        colours = %w[red green blue]
+        colours = colours.map(&:capitalize) if MiniMagick.imagemagick7?
+        colours.map { |colour| image.data.dig('channelStatistics', colour, 'mean').to_s }
+      end
+    end
+  end
+end


### PR DESCRIPTION
There is a potential process leak style issue where successive calls to Schmooze will result in node processes being started and not being cleaned up. This also appears to have the side effect of the node process preventing regular Chrome from being able to quit due to some sort of shared memory mutex shared with Chromium that the node process is somehow holding on to. The process is not cleaned up due to how Schmooze uses the Ruby garbage collector to clean up the node process, which has been seen to potentially stick around for a considerable amount of time. If enough Grover instances were launched it would likely result in some sort of resource contention.

Given Grover instantiates a new instance of the Schmooze processor for each call, there is really no need for the node process to be kept alive once the document conversion is complete, thus this PR removes Schmooze in favour of a built in fork that is somewhat tailored for the Grover process. 