### PR TITLE
Ensure cookies from incoming request are passed to Grover via Middleware

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,7 +23,7 @@ Metrics/BlockLength:
     - "**/*_spec.rb"
 
 Metrics/ClassLength:
-  Max: 135
+  Max: 140
 
 RSpec/ExampleLength:
   Max: 12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
 ## Unreleased
-- None
+
+### Added
+- (https://github.com/Studiosity/grover/pull/63) Ensure cookies from incoming request are passed to Grover via Middleware
+
 
 ## [0.12.1](releases/tag/v0.12.1) - 2020-05-12
 ### Fixed
@@ -31,7 +34,7 @@
 
 ## [0.10.1](releases/tag/v0.10.1) - 2020-01-13
 ### Fixed
-- [#39](https://github.com/Studiosity/grover/pull/39) Fix middleware thread safety issue ([@jnimety][]) 
+- [#39](https://github.com/Studiosity/grover/pull/39) Fix middleware thread safety issue ([@jnimety][])
 
 ## [0.9.2](releases/tag/v0.9.2) - 2019-12-27
 ### Added
@@ -65,10 +68,10 @@
 ## [0.7.4](releases/tag/v0.7.4) - 2019-07-09
 ### Breaking change
 - [#18](https://github.com/Studiosity/grover/pull/18) Use `GROVER_NO_SANDBOX` for disabling sandbox ([@koenhandekyn][])
- 
+
 ## [0.7.3](releases/tag/v0.7.3) - 2019-05-23
 ### Fixed
-- [#14](https://github.com/Studiosity/grover/pull/14) Metadata options not included if source contained *any* line starting with `http` 
+- [#14](https://github.com/Studiosity/grover/pull/14) Metadata options not included if source contained *any* line starting with `http`
 - [#15](https://github.com/Studiosity/grover/pull/15) Add magic comment for freezing string literals
 
 ## [0.7.2](releases/tag/v0.7.2) - 2019-01-22
@@ -89,7 +92,7 @@
 
 ### Breaking change
 - The `{{display_url}}` header/footer hack was removed in favour of passing the URL via `display_url` option
-  (for middleware/raw HTML only) 
+  (for middleware/raw HTML only)
 
 ## [0.5.5](releases/tag/v0.5.5) - 2018-09-20
 ### Fixed
@@ -117,7 +120,7 @@
 
 ## [0.4.3](releases/tag/v0.4.3) - 2018-09-10
 ### Added
-- Pass through flag to indicate to upstream middleware/app that Grover has interacted with the environment 
+- Pass through flag to indicate to upstream middleware/app that Grover has interacted with the environment
 
 ## [0.4.2](releases/tag/v0.4.2) - 2018-09-09
 ### Fixed
@@ -165,11 +168,11 @@
 - Processor support for inline HTML (render via the URI rather than trying to `setContent`)
 
 ### Changed
-- Minor refactor of middleware for readability 
+- Minor refactor of middleware for readability
 
 ## [0.2.0](releases/tag/v0.2.0) - 2018-08-23
 ### Added
-- Rack middleware for rendering upstream HTML as PDF (based heavily on PDFKit middleware) 
+- Rack middleware for rendering upstream HTML as PDF (based heavily on PDFKit middleware)
 - Allow PDF processor to handle inline HTML
 
 ### Fixed
@@ -189,17 +192,17 @@
 ## [0.1.0](releases/tag/v0.1.0) - 2018-08-22
 ### Added
 - First pass at PDF processor
-- Console script for expediting development 
+- Console script for expediting development
 
 ## [0.0.1](releases/tag/v0.0.1) - 2018-08-22
 ### Added
-- Initial gem framework 
+- Initial gem framework
 
 [@koenhandekyn]: https://github.com/koenhandekyn
 [@joergschiller]: https://github.com/joergschiller
 [@ryansmith23]: https://github.com/ryansmith23
-[@rwtaylor]: https://github.com/rwtaylor 
+[@rwtaylor]: https://github.com/rwtaylor
 [@jnimety]: https://github.com/jnimety
 [@willkoehler]: https://github.com/willkoehler
 [@Richacinas]: https://github.com/Richacinas
-[@inspiredstuffs]: https://github.com/inspiredstuffs 
+[@inspiredstuffs]: https://github.com/inspiredstuffs

--- a/lib/grover/middleware.rb
+++ b/lib/grover/middleware.rb
@@ -100,10 +100,8 @@ class Grover
       body = HTMLPreprocessor.process body, root_url, protocol
 
       options = { display_url: request_url }
-
-      if (cookies = cookies_from_env).any?
-        options[:cookies] = cookies
-      end
+      cookies = cookies_from_env
+      options[:cookies] = cookies if cookies.any?
 
       Grover.new(body, options)
     end

--- a/lib/grover/middleware.rb
+++ b/lib/grover/middleware.rb
@@ -100,6 +100,7 @@ class Grover
       body = HTMLPreprocessor.process body, root_url, protocol
 
       options = { display_url: request_url }
+
       if (cookies = cookies_from_env).any?
         options[:cookies] = cookies
       end

--- a/lib/grover/middleware.rb
+++ b/lib/grover/middleware.rb
@@ -97,9 +97,14 @@ class Grover
     def create_grover_for_response(response)
       body = response.respond_to?(:body) ? response.body : response.join
       body = body.join if body.is_a?(Array)
-
       body = HTMLPreprocessor.process body, root_url, protocol
-      Grover.new(body, display_url: request_url)
+
+      options = { display_url: request_url }
+      if (cookies = cookies_from_env).any?
+        options[:cookies] = cookies
+      end
+
+      Grover.new(body, options)
     end
 
     def add_cover_content(grover)
@@ -175,6 +180,13 @@ class Grover
       env['rack.input'] = StringIO.new
       env.delete 'CONTENT_LENGTH'
       env.delete 'RAW_POST_DATA'
+    end
+
+    def cookies_from_env
+      env['HTTP_COOKIE'].to_s.split('; ').map do |cookie|
+        key, value = cookie.split '='
+        { name: key, value: value, domain: env['HTTP_HOST'] }
+      end
     end
   end
 end

--- a/lib/grover/middleware.rb
+++ b/lib/grover/middleware.rb
@@ -100,7 +100,9 @@ class Grover
       body = HTMLPreprocessor.process body, root_url, protocol
 
       options = { display_url: request_url }
-      cookies = cookies_from_env
+      cookies = Rack::Utils.parse_cookies(env).map do |name, value|
+        { name: name, value: value, domain: env['HTTP_HOST'] }
+      end
       options[:cookies] = cookies if cookies.any?
 
       Grover.new(body, options)
@@ -179,13 +181,6 @@ class Grover
       env['rack.input'] = StringIO.new
       env.delete 'CONTENT_LENGTH'
       env.delete 'RAW_POST_DATA'
-    end
-
-    def cookies_from_env
-      env['HTTP_COOKIE'].to_s.split('; ').map do |cookie|
-        key, value = cookie.split '='
-        { name: key, value: value, domain: env['HTTP_HOST'] }
-      end
     end
   end
 end

--- a/spec/grover/middleware_spec.rb
+++ b/spec/grover/middleware_spec.rb
@@ -380,7 +380,8 @@ describe Grover::Middleware do
       it 'passes through cookies to Grover' do
         expect(Grover).to(
           receive(:new).
-            with('Grover McGroveryface',
+            with(
+              'Grover McGroveryface',
               display_url: 'http://www.example.org/test',
               cookies: [{ domain: 'www.example.org', name: 'key', value: 'value' }]
             ).and_return(grover)

--- a/spec/grover/middleware_spec.rb
+++ b/spec/grover/middleware_spec.rb
@@ -387,7 +387,7 @@ describe Grover::Middleware do
             ).and_return(grover)
         )
         expect(grover).to receive(:to_pdf).with(no_args).and_return 'A converted PDF'
-        get 'http://www.example.org/test.pdf', nil, { 'HTTP_COOKIE' => 'key=value' }
+        get 'http://www.example.org/test.pdf', nil, 'HTTP_COOKIE' => 'key=value'
         expect(last_response.body).to eq 'A converted PDF'
       end
 

--- a/spec/grover/middleware_spec.rb
+++ b/spec/grover/middleware_spec.rb
@@ -377,6 +377,19 @@ describe Grover::Middleware do
         expect(last_response.body).to eq 'A converted PDF'
       end
 
+      it 'passes through cookies to Grover' do
+        expect(Grover).to(
+          receive(:new).
+            with('Grover McGroveryface',
+              display_url: 'http://www.example.org/test',
+              cookies: [{:domain=>"www.example.org", :name=>"key", :value=>"value;"}]
+            ).and_return(grover)
+        )
+        expect(grover).to receive(:to_pdf).with(no_args).and_return 'A converted PDF'
+        get 'http://www.example.org/test.pdf', nil, { 'HTTP_COOKIE' => 'key=value;' }
+        expect(last_response.body).to eq 'A converted PDF'
+      end
+
       context 'when app configuration has PDF middleware disabled' do
         before { allow(Grover.configuration).to receive(:use_pdf_middleware).and_return false }
 
@@ -411,6 +424,19 @@ describe Grover::Middleware do
           expect(last_response.body).to eq 'A converted PNG'
         end
       end
+
+      it 'passes through cookies to Grover' do
+        expect(Grover).to(
+          receive(:new).
+            with('Grover McGroveryface',
+              display_url: 'http://www.example.org/test',
+              cookies: [{:domain=>"www.example.org", :name=>"key", :value=>"value;"}]
+            ).and_return(grover)
+        )
+        expect(grover).to receive(:to_pdf).with(no_args).and_return 'A converted PDF'
+        get 'http://www.example.org/test.png', nil, { 'HTTP_COOKIE' => 'key=value;' }
+        expect(last_response.body).to eq 'A converted PDF'
+      end
     end
 
     describe 'jpeg conversion' do
@@ -435,6 +461,19 @@ describe Grover::Middleware do
           get 'http://www.example.org/test.jpeg'
           expect(last_response.body).to eq 'A converted JPEG'
         end
+      end
+
+      it 'passes through cookies to Grover' do
+        expect(Grover).to(
+          receive(:new).
+            with('Grover McGroveryface',
+              display_url: 'http://www.example.org/test',
+              cookies: [{:domain=>"www.example.org", :name=>"key", :value=>"value;"}]
+            ).and_return(grover)
+        )
+        expect(grover).to receive(:to_pdf).with(no_args).and_return 'A converted PDF'
+        get 'http://www.example.org/test.jpeg', nil, { 'HTTP_COOKIE' => 'key=value;' }
+        expect(last_response.body).to eq 'A converted PDF'
       end
     end
 

--- a/spec/grover/middleware_spec.rb
+++ b/spec/grover/middleware_spec.rb
@@ -382,11 +382,11 @@ describe Grover::Middleware do
           receive(:new).
             with('Grover McGroveryface',
               display_url: 'http://www.example.org/test',
-              cookies: [{:domain=>"www.example.org", :name=>"key", :value=>"value;"}]
+              cookies: [{ domain: 'www.example.org', name: 'key', value: 'value' }]
             ).and_return(grover)
         )
         expect(grover).to receive(:to_pdf).with(no_args).and_return 'A converted PDF'
-        get 'http://www.example.org/test.pdf', nil, { 'HTTP_COOKIE' => 'key=value;' }
+        get 'http://www.example.org/test.pdf', nil, { 'HTTP_COOKIE' => 'key=value' }
         expect(last_response.body).to eq 'A converted PDF'
       end
 
@@ -424,19 +424,6 @@ describe Grover::Middleware do
           expect(last_response.body).to eq 'A converted PNG'
         end
       end
-
-      it 'passes through cookies to Grover' do
-        expect(Grover).to(
-          receive(:new).
-            with('Grover McGroveryface',
-              display_url: 'http://www.example.org/test',
-              cookies: [{:domain=>"www.example.org", :name=>"key", :value=>"value;"}]
-            ).and_return(grover)
-        )
-        expect(grover).to receive(:to_pdf).with(no_args).and_return 'A converted PDF'
-        get 'http://www.example.org/test.png', nil, { 'HTTP_COOKIE' => 'key=value;' }
-        expect(last_response.body).to eq 'A converted PDF'
-      end
     end
 
     describe 'jpeg conversion' do
@@ -461,19 +448,6 @@ describe Grover::Middleware do
           get 'http://www.example.org/test.jpeg'
           expect(last_response.body).to eq 'A converted JPEG'
         end
-      end
-
-      it 'passes through cookies to Grover' do
-        expect(Grover).to(
-          receive(:new).
-            with('Grover McGroveryface',
-              display_url: 'http://www.example.org/test',
-              cookies: [{:domain=>"www.example.org", :name=>"key", :value=>"value;"}]
-            ).and_return(grover)
-        )
-        expect(grover).to receive(:to_pdf).with(no_args).and_return 'A converted PDF'
-        get 'http://www.example.org/test.jpeg', nil, { 'HTTP_COOKIE' => 'key=value;' }
-        expect(last_response.body).to eq 'A converted PDF'
       end
     end
 


### PR DESCRIPTION
I came across this situation this week, where I was loading a page that had javascript based  calendar which loaded additional resources. While the page loaded the JSON that populated the calendar did not because the AJAX calls to fetch data did not have the cookies it needed.

This just reuses the example of re-sending cookies, but it puts it into the middleware.