### PR TITLE
Fix bug masking NodeJS launch failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## Unreleased
-- None
+### Fixed
+- [#66](https://github.com/Studiosity/grover/pull/66) Fix bug masking NodeJS launch failures
 
 ## [0.12.1](releases/tag/v0.12.1) - 2020-05-12
 ### Fixed

--- a/lib/grover/processor.rb
+++ b/lib/grover/processor.rb
@@ -22,7 +22,7 @@ class Grover
 
       result['data'].pack('C*')
     ensure
-      cleanup_process
+      cleanup_process if stdin
     end
 
     private

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   },
   "homepage": "https://github.com/Studiosity/grover#readme",
   "devDependencies": {
-    "puppeteer": "^3.0.4"
+    "puppeteer": "^3.3.0"
   }
 }

--- a/spec/grover/processor_spec.rb
+++ b/spec/grover/processor_spec.rb
@@ -144,6 +144,14 @@ describe Grover::Processor do
             expect { convert }.to raise_error Grover::JavaScript::UnknownError, 'Some unknown thing happened'
           end
         end
+
+        context 'when the call to launch Node raises an error' do
+          it 'raises the error' do
+            expect(Open3).to receive(:popen3).and_raise Errno::ENOENT, 'node'
+
+            expect { convert }.to raise_error Errno::ENOENT, 'No such file or directory - node'
+          end
+        end
       end
 
       context 'when passing through html' do


### PR DESCRIPTION
Fixes bug where problems occurring while launching the NodeJS process are masked by an error raised when trying to "close" the unassigned IO

Resolves #65