### PR TITLE
Fix bug in middleware where path/URI weren't restored after calling downstream

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,27 +12,51 @@ Layout/LineLength:
 Layout/SpaceAroundMethodCallOperator:
   Enabled: true
 
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: true
+
 Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+
+Lint/DuplicateElsifCondition:
+  Enabled: true
+
+Lint/DuplicateRescueException:
+  Enabled: true
+
+Lint/EmptyConditionalBody:
+  Enabled: true
+
+Lint/FloatComparison:
+  Enabled: true
+
+Lint/MissingSuper:
   Enabled: true
 
 Lint/MixedRegexpCaptureTypes:
   Enabled: true
 
+Lint/OutOfRangeRegexpRef:
+  Enabled: true
+
 Lint/RaiseException:
+  Enabled: true
+
+Lint/SelfAssignment:
   Enabled: true
 
 Lint/StructNewOverride:
   Enabled: true
 
-Metrics/AbcSize:
-    Max: 20
+Lint/TopLevelReturnWithArgument:
+  Enabled: true
+
+Lint/UnreachableLoop:
+  Enabled: true
 
 Metrics/BlockLength:
   Exclude:
     - "**/*_spec.rb"
-
-Metrics/ClassLength:
-  Max: 140
 
 RSpec/ExampleLength:
   Max: 12
@@ -41,19 +65,46 @@ RSpec/MessageSpies:
   EnforcedStyle: receive
 
 RSpec/MultipleExpectations:
-  Max: 4
+  Max: 6
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
 
 RSpec/NestedGroups:
   Max: 6
+
+Style/AccessorGrouping:
+  Enabled: true
+
+Style/ArrayCoercion:
+  Enabled: true
+
+Style/BisectedAttrAccessor:
+  Enabled: true
+
+Style/CaseLikeIf:
+  Enabled: true
 
 Style/Documentation:
   Exclude:
     - "lib/active_support_ext/**/*.rb"
 
+Style/ExplicitBlockArgument:
+  Enabled: true
+
 Style/ExponentialNotation:
   Enabled: true
 
+Style/GlobalStdStream:
+  Enabled: true
+
+Style/HashAsLastArrayItem:
+  Enabled: true
+
 Style/HashEachMethods:
+  Enabled: true
+
+Style/HashLikeCase:
   Enabled: true
 
 Style/HashTransformKeys:
@@ -62,7 +113,16 @@ Style/HashTransformKeys:
 Style/HashTransformValues:
   Enabled: true
 
+Style/OptionalBooleanParameter:
+  Enabled: true
+
+Style/RedundantAssignment:
+  Enabled: true
+
 Style/RedundantFetchBlock:
+  Enabled: true
+
+Style/RedundantFileExtensionInRequire:
   Enabled: true
 
 Style/RedundantRegexpCharacterClass:
@@ -71,5 +131,11 @@ Style/RedundantRegexpCharacterClass:
 Style/RedundantRegexpEscape:
   Enabled: true
 
+Style/SingleArgumentDig:
+  Enabled: true
+
 Style/SlicingWithRange:
+  Enabled: true
+
+Style/StringConcatenation:
   Enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,14 @@ env:
     - PUPPETEER_VERSION=1.20.0
     - PUPPETEER_VERSION=2.1.1
     - PUPPETEER_VERSION=3.0.4
+    - PUPPETEER_VERSION=4.0.1
+    - PUPPETEER_VERSION=5.2.1
 
 language: ruby
 rvm:
-  - 2.3
-  - 2.4
   - 2.5
   - 2.6
+  - 2.7
 
 before_install:
   - nvm install 10
@@ -19,7 +20,7 @@ before_install:
 
 install:
   - bundle install --jobs=3 --retry=3
-  - ruby --version | grep '^ruby 2\.3\.' > /dev/null || gem install rubocop
+  - gem install rubocop
   - npm install puppeteer@$PUPPETEER_VERSION
 
 before_script:
@@ -28,7 +29,7 @@ before_script:
   - ./cc-test-reporter before-build
 
 script:
-  - ruby --version | grep '^ruby 2\.3\.' > /dev/null || rubocop
+  - rubocop
   - bundle exec rspec
 
 after_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## Unreleased
-- None
+### Fixed
+- [#79](https://github.com/Studiosity/grover/pull/79) Fix bug in middleware where path/URI weren't restored after calling downstream
 
 ## [0.12.3](releases/tag/v0.12.3) - 2020-07-01
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Travis Build Status](https://img.shields.io/travis/Studiosity/grover/master.svg?style=flat)](https://travis-ci.org/Studiosity/grover)
+[![Travis Build Status](https://travis-ci.org/Studiosity/grover.svg?branch=main)](https://travis-ci.org/Studiosity/grover)
 [![Maintainability](https://api.codeclimate.com/v1/badges/37609653789bcf2c8d94/maintainability)](https://codeclimate.com/github/Studiosity/grover/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/37609653789bcf2c8d94/test_coverage)](https://codeclimate.com/github/Studiosity/grover/test_coverage)
 [![Gem Version](https://badge.fury.io/rb/grover.svg)](https://badge.fury.io/rb/grover)

--- a/grover.gemspec
+++ b/grover.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
   SUMMARY
   spec.homepage    = 'https://github.com/Studiosity/grover'
   spec.license     = 'MIT'
+  spec.required_ruby_version = ['>= 2.5.0', '< 2.8.0']
 
   spec.files         = `git ls-files lib`.split("\n")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/lib/grover/middleware.rb
+++ b/lib/grover/middleware.rb
@@ -9,7 +9,7 @@ class Grover
   # Much of this code was sourced from the PDFKit project
   # @see https://github.com/pdfkit/pdfkit
   #
-  class Middleware
+  class Middleware # rubocop:disable Metrics/ClassLength
     def initialize(app)
       @app = app
       @pdf_request = false
@@ -27,7 +27,10 @@ class Grover
 
       configure_env_for_grover_request(env) if grover_request?
       status, headers, response = @app.call(env)
-      response = update_response response, headers if grover_request? && html_content?(headers)
+      if grover_request?
+        response = update_response response, headers if html_content?(headers)
+        restore_env_from_grover_request(env)
+      end
 
       [status, headers, response]
     end
@@ -94,7 +97,7 @@ class Grover
       end
     end
 
-    def create_grover_for_response(response)
+    def create_grover_for_response(response) # rubocop:disable Metrics/AbcSize
       body = response.respond_to?(:body) ? response.body : response.join
       body = body.join if body.is_a?(Array)
       body = HTMLPreprocessor.process body, root_url, protocol
@@ -135,9 +138,20 @@ class Grover
     end
 
     def configure_env_for_grover_request(env)
-      env['PATH_INFO'] = env['REQUEST_URI'] = path_without_extension
+      # Save the env params we're overriding so we can restore them after the response is fetched
+      @pre_request_env_params = env.slice('PATH_INFO', 'REQUEST_URI', 'HTTP_ACCEPT')
+
+      # Override path/URI so any downstream middleware/app doesn't try actioning the request as PDF
+      env['PATH_INFO'] = path_without_extension
+      env['REQUEST_URI'] = @request.url
       env['HTTP_ACCEPT'] = concat(env['HTTP_ACCEPT'], Rack::Mime.mime_type('.html'))
       env['Rack-Middleware-Grover'] = 'true'
+    end
+
+    def restore_env_from_grover_request(env)
+      # Restore the path/URI so any upstream middleware doesn't get confused
+      env.merge! @pre_request_env_params
+      env['REQUEST_URI'] = @request.url unless @pre_request_env_params.key? 'REQUEST_URI'
     end
 
     def concat(accepts, type)

--- a/lib/grover/middleware.rb
+++ b/lib/grover/middleware.rb
@@ -27,12 +27,11 @@ class Grover
 
       configure_env_for_grover_request(env) if grover_request?
       status, headers, response = @app.call(env)
-      if grover_request?
-        response = update_response response, headers if html_content?(headers)
-        restore_env_from_grover_request(env)
-      end
+      response = update_response response, headers if grover_request? && html_content?(headers)
 
       [status, headers, response]
+    ensure
+      restore_env_from_grover_request(env) if grover_request?
     end
 
     private
@@ -149,6 +148,8 @@ class Grover
     end
 
     def restore_env_from_grover_request(env)
+      return unless @pre_request_env_params.is_a? Hash
+
       # Restore the path/URI so any upstream middleware doesn't get confused
       env.merge! @pre_request_env_params
       env['REQUEST_URI'] = @request.url unless @pre_request_env_params.key? 'REQUEST_URI'

--- a/lib/grover/options_builder.rb
+++ b/lib/grover/options_builder.rb
@@ -8,7 +8,7 @@ class Grover
   # Build options from Grover.configuration, meta_options, and passed-in options
   #
   class OptionsBuilder < Hash
-    def initialize(options, url)
+    def initialize(options, url) # rubocop:disable Lint/MissingSuper
       @url = url
       combined = grover_configuration
       Utils.deep_merge! combined, Utils.deep_stringify_keys(options)

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   },
   "homepage": "https://github.com/Studiosity/grover#readme",
   "devDependencies": {
-    "puppeteer": "^3.3.0"
+    "puppeteer": "^5.2.1"
   }
 }


### PR DESCRIPTION
The issue manifested itself in the Capybara middleware, although it's possible to see the same issue elsewhere. In short, v3.30 of Capybara modified its middleware to track the request URIs instead of just the count. When the response came back it would remove the URI from the list of current requests. Unfortunately this would break when Grover modifies the URI. As a result Capybara would leave the request in it's list of current requests resulting in it thinking there was some long running request when in truth everything was fine!

Although the issue in the Capybara middleware [has been fixed](https://github.com/teamcapybara/capybara/pull/2378) it's safest to just have Grover restore the env (where possible/practical) once the downstream request has been fulfilled.

Also addressed:

Drop Ruby 2.3 and 2.4 support
Add Ruby 2.7 support
Update Rubocop configuration to latest (v0.89.1)
Fix Travis build badge