### PR TITLE
rescue JSON::ParserError 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 *.gem
 Gemfile.lock
 package-lock.json
+yarn.lock
+.bundle
 /node_modules
 /coverage
+/vendor

--- a/lib/grover/processor.rb
+++ b/lib/grover/processor.rb
@@ -90,7 +90,7 @@ class Grover
       else
         raise Grover::JavaScript.const_get(error_class, false), message
       end
-    rescue Errno::EPIPE, IOError
+    rescue Errno::EPIPE, IOError, JSON::ParserError
       raise Grover::Error, "Worker process failed:\n#{stderr.read}"
     end
 


### PR DESCRIPTION
can happen when node craps out due to OOM error (issue #81)