### PR TITLE
Update gem name for combining PDF files

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Or via the meta tags in the original response:
 ### Direct execution
 
 To add a cover page using direct execution, you can make multiple calls and combine the results using the
-`combine_pdfs` gem.
+`combine_pdf` gem.
 
 ```rb
 require 'combine_pdf'


### PR DESCRIPTION
`combine_pdf` seems to be a proper [gem name](https://github.com/boazsegev/combine_pdf)

```
➜   gem install combine_pdfs
ERROR:  Could not find a valid gem 'combine_pdfs' (>= 0) in any repository
ERROR:  Possible alternatives: combine_pdf, compile_pdf
```