### PR TITLE
Add root_url option to middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,25 @@ Grover.configure do |config|
 end
 ```
 
+### root_url
+The `root_url` option can be specified either when configuring the middleware or as a global option. This is needed
+when running the Grover middleware behind a URL rewriting proxy or within a containerised system.
+
+As a middleware option:
+```ruby
+# in application.rb
+require 'grover'
+config.middleware.use Grover::Middleware, root_url: 'https://my.external.domain'
+```
+
+or as a global option:
+```ruby
+# config/initializers/grover.rb
+Grover.configure do |config|
+  config.root_url = 'https://my.external.domain'
+end
+```
+
 #### ignore_path
 The `ignore_path` configuration option can be used to tell Grover's middleware whether it should handle/modify
 the response. There are three ways to set up the `ignore_path`:

--- a/lib/grover/configuration.rb
+++ b/lib/grover/configuration.rb
@@ -5,13 +5,14 @@ class Grover
   # Configuration of the options for Grover HTML to PDF conversion
   #
   class Configuration
-    attr_accessor :options, :meta_tag_prefix, :ignore_path,
+    attr_accessor :options, :meta_tag_prefix, :ignore_path, :root_url,
                   :use_pdf_middleware, :use_png_middleware, :use_jpeg_middleware
 
     def initialize
       @options = {}
       @meta_tag_prefix = 'grover-'
       @ignore_path = nil
+      @root_url = nil
       @use_pdf_middleware = true
       @use_png_middleware = false
       @use_jpeg_middleware = false

--- a/lib/grover/middleware.rb
+++ b/lib/grover/middleware.rb
@@ -16,9 +16,7 @@ class Grover
       @png_request = false
       @jpeg_request = false
 
-      options = Grover.configuration.options
-      @root_url = options[:root_url]
-      @root_url = args.last[:root_url] if args.last.is_a? Hash
+      @root_url = args.last.is_a?(Hash) ? args.last[:root_url] : Grover.configuration.options[:root_url]
     end
 
     def call(env)

--- a/lib/grover/middleware.rb
+++ b/lib/grover/middleware.rb
@@ -10,11 +10,15 @@ class Grover
   # @see https://github.com/pdfkit/pdfkit
   #
   class Middleware # rubocop:disable Metrics/ClassLength
-    def initialize(app)
+    def initialize(app, *args)
       @app = app
       @pdf_request = false
       @png_request = false
       @jpeg_request = false
+
+      options = Grover.configuration.options
+      @root_url = options[:root_url]
+      @root_url = args.last[:root_url] if args.last.is_a? Hash
     end
 
     def call(env)

--- a/lib/grover/middleware.rb
+++ b/lib/grover/middleware.rb
@@ -16,7 +16,8 @@ class Grover
       @png_request = false
       @jpeg_request = false
 
-      @root_url = args.last.is_a?(Hash) ? args.last[:root_url] : Grover.configuration.options[:root_url]
+      @root_url =
+        args.last.is_a?(Hash) && args.last.key?(:root_url) ? args.last[:root_url] : Grover.configuration.root_url
     end
 
     def call(env)

--- a/spec/grover/configuration_spec.rb
+++ b/spec/grover/configuration_spec.rb
@@ -25,4 +25,16 @@ describe Grover::Configuration do
       it { is_expected.to eq 'fooPrefix-' }
     end
   end
+
+  describe '#root_url' do
+    subject(:root_url) { configuration.root_url }
+
+    it { is_expected.to be_nil }
+
+    context 'when configured differently' do
+      before { configuration.root_url = 'https://my.domain' }
+
+      it { is_expected.to eq 'https://my.domain' }
+    end
+  end
 end

--- a/spec/grover/middleware_spec.rb
+++ b/spec/grover/middleware_spec.rb
@@ -455,16 +455,25 @@ describe Grover::Middleware do
         end
       end
 
-      context 'converts relative paths' do
+      context 'when path is relative' do
         let(:response) { ['src="/asdf"'] }
 
-        context 'with root_url specified' do
+        context 'with root_url specified via middleware args' do
           subject(:mock_app) do
             builder = Rack::Builder.new
             builder.use described_class, root_url: 'http://example.com/'
             builder.run downstream
             builder.to_app
           end
+
+          it 'uses the specified root_url' do
+            get 'http://www.example.org/test.pdf'
+            expect(last_response.body.bytesize).to eq Grover.new('src="http://example.com/asdf"').to_pdf.bytesize
+          end
+        end
+
+        context 'with root_url set in configuration' do
+          before { allow(Grover.configuration).to receive(:options).and_return({ root_url: 'http://example.com/' }) }
 
           it 'uses the specified root_url' do
             get 'http://www.example.org/test.pdf'

--- a/spec/grover/middleware_spec.rb
+++ b/spec/grover/middleware_spec.rb
@@ -435,6 +435,50 @@ describe Grover::Middleware do
         get 'http://www.example.org/test.pdf'
         expect(last_response.body.bytesize).to eq Grover.new('Processed McProcessyface').to_pdf.bytesize
       end
+
+      context 'with root_url specified' do
+        subject(:mock_app) do
+          builder = Rack::Builder.new
+          builder.use described_class, root_url: 'http://example.com/'
+          builder.run downstream
+          builder.to_app
+        end
+
+        it 'calls to the HTML preprocessor with the original HTML and the specified root_url' do
+          expect(Grover::HTMLPreprocessor).to(
+            receive(:process).
+              with('Grover McGroveryface', 'http://example.com/', 'http').
+              and_return('Processed McProcessyface')
+          )
+          get 'http://www.example.org/test.pdf'
+          expect(last_response.body.bytesize).to eq Grover.new('Processed McProcessyface').to_pdf.bytesize
+        end
+      end
+
+      context 'converts relative paths' do
+        let(:response) { ['src="/asdf"'] }
+
+        context 'with root_url specified' do
+          subject(:mock_app) do
+            builder = Rack::Builder.new
+            builder.use described_class, root_url: 'http://example.com/'
+            builder.run downstream
+            builder.to_app
+          end
+
+          it 'uses the specified root_url' do
+            get 'http://www.example.org/test.pdf'
+            expect(last_response.body.bytesize).to eq Grover.new('src="http://example.com/asdf"').to_pdf.bytesize
+          end
+        end
+
+        context 'without root_url specified' do
+          it 'uses the detected root_url (request url)' do
+            get 'http://www.example.org/test.pdf'
+            expect(last_response.body.bytesize).to eq Grover.new('src="http://www.example.org/asdf"').to_pdf.bytesize
+          end
+        end
+      end
     end
 
     describe 'pdf conversion' do

--- a/spec/grover/middleware_spec.rb
+++ b/spec/grover/middleware_spec.rb
@@ -476,7 +476,7 @@ describe Grover::Middleware do
           end
 
           context 'when the root_url is also set in configuration' do
-            before { allow(Grover.configuration).to receive(:options).and_return({ root_url: 'http://other.domain/' }) }
+            before { allow(Grover.configuration).to receive(:root_url).and_return 'http://other.domain/' }
 
             it 'uses the specified root_url in the middleware initializer' do
               get 'http://www.example.org/test.pdf'
@@ -486,7 +486,7 @@ describe Grover::Middleware do
         end
 
         context 'with root_url set in configuration' do
-          before { allow(Grover.configuration).to receive(:options).and_return({ root_url: 'http://example.com/' }) }
+          before { allow(Grover.configuration).to receive(:root_url).and_return 'http://example.com/' }
 
           it 'uses the specified root_url' do
             get 'http://www.example.org/test.pdf'


### PR DESCRIPTION
Fixes #83
Closes #84 

Add `root_url` option available as either a configuration option for the middleware or as a global configuration option (middleware option taking precedence)
