### PR TITLE
Handle `nil` and empty string content edge-cases

### DIFF
--- a/lib/grover.rb
+++ b/lib/grover.rb
@@ -33,8 +33,8 @@ class Grover
   #   see https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagepdfoptions
   #
   def initialize(url, options = {})
-    @url = url
-    @options = OptionsBuilder.new(options, url)
+    @url = url.to_s
+    @options = OptionsBuilder.new(options, @url)
     @root_path = @options.delete 'root_path'
     @front_cover_path = @options.delete 'front_cover_path'
     @back_cover_path = @options.delete 'back_cover_path'

--- a/lib/grover/js/processor.js
+++ b/lib/grover/js/processor.js
@@ -82,7 +82,7 @@ const _processPage = (async (convertAction, urlOrHtml, options) => {
       requestOptions.waitUntil = waitUntil || 'networkidle0';
       await page.setRequestInterception(true);
       page.once('request', request => {
-        request.respond({ body: urlOrHtml });
+        request.respond({ body: urlOrHtml === '' ? ' ' : urlOrHtml });
         // Reset the request interception
         // (we only want to intercept the first request - ie our HTML)
         page.on('request', request => request.continue());

--- a/spec/grover/processor_spec.rb
+++ b/spec/grover/processor_spec.rb
@@ -55,6 +55,14 @@ describe Grover::Processor do
         end
       end
 
+      context 'when passing through an empty string' do
+        let(:url_or_html) { '' }
+
+        it { is_expected.to start_with "%PDF-1.4\n" }
+        it { expect(pdf_reader.page_count).to eq 1 }
+        it { expect(pdf_text_content).to eq '' }
+      end
+
       context 'when puppeteer package is not installed' do
         # Temporarily move the node puppeteer folder
         before { FileUtils.move 'node_modules/puppeteer', 'node_modules/puppeteer_temp' }

--- a/spec/grover_spec.rb
+++ b/spec/grover_spec.rb
@@ -31,6 +31,14 @@ describe Grover do
         it { expect(new.instance_variable_get('@options')).to eq('page_size' => 'A4') }
       end
     end
+
+    context 'when url provided is `nil`' do
+      subject(:new) { described_class.new(nil) }
+
+      it { expect(new.instance_variable_get('@url')).to eq '' }
+      it { expect(new.instance_variable_get('@root_path')).to be_nil }
+      it { expect(new.instance_variable_get('@options')).to eq({}) }
+    end
   end
 
   describe '#to_pdf' do


### PR DESCRIPTION
Resolves #94 

Handle `nil` input case by treating it as an empty string (convert all input to a string with `to_s`)

Handle empty string case in the processor by passing a single space to Puppeteer instead. Likely cause is that Puppeteer is taking an empty string to mean "not provided" and thus ignoring the call to `respond`, instead choosing to wait for further input.. which never comes:

https://github.com/puppeteer/puppeteer/blob/v5.5.0/docs/api.md#httprequestrespondresponse