### PR TITLE
Add waitForFunction support

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ For available options see https://github.com/puppeteer/puppeteer/blob/main/docs/
 
 The `wait_for_selector` option can also be used to wait until an element appears on the page. Additional waiting parameters can be set with the `wait_for_selector_options` options hash. For available options, see: https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pagewaitforselectorselector-options.
 
+The `wait_for_function` option can be used to wait until a specific function returns a truthy value. Additional parameters can be set with the `wait_for_function_options` options has. For available options, see: https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pagewaitforfunctionpagefunction-options-args
+
 The `wait_for_timeout` option can also be used to wait the specified number of milliseconds have elapsed.
 
 The `raise_on_request_failure` option, when enabled, will raise a `Grover::JavaScript::RequestFailedError`

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ For available options see https://github.com/puppeteer/puppeteer/blob/main/docs/
 
 The `wait_for_selector` option can also be used to wait until an element appears on the page. Additional waiting parameters can be set with the `wait_for_selector_options` options hash. For available options, see: https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pagewaitforselectorselector-options.
 
-The `wait_for_function` option can be used to wait until a specific function returns a truthy value. Additional parameters can be set with the `wait_for_function_options` options has. For available options, see: https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pagewaitforfunctionpagefunction-options-args
+The `wait_for_function` option can be used to wait until a specific function returns a truthy value. Additional parameters can be set with the `wait_for_function_options` options hash. For available options, see: https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pagewaitforfunctionpagefunction-options-args
 
 The `wait_for_timeout` option can also be used to wait the specified number of milliseconds have elapsed.
 

--- a/lib/grover/js/processor.js
+++ b/lib/grover/js/processor.js
@@ -184,6 +184,13 @@ const _processPage = (async (convertAction, urlOrHtml, options) => {
       await page.waitForSelector(waitForSelector, waitForSelectorOptions);
     }
 
+    // If specified, wait for function
+    const waitForFunction = options.waitForFunction; delete options.waitForFunction;
+    const waitForFunctionOptions = options.waitForFunctionOptions; delete options.waitForFunctionOptions;
+    if (waitForFunction !== undefined) {
+      await page.waitForFunction(waitForFunction, waitForFunctionOptions);
+    }
+
     // If specified, wait for timeout
     const waitForTimeout = options.waitForTimeout; delete options.waitForTimeout;
     if (waitForTimeout !== undefined) {

--- a/spec/grover/processor_spec.rb
+++ b/spec/grover/processor_spec.rb
@@ -490,6 +490,30 @@ describe Grover::Processor do
         it { expect(pdf_text_content).to eq "#{date} Hey there http://www.example.net/foo/bar 1/1" }
       end
 
+      context 'when wait for function option is specified' do
+        let(:url_or_html) do
+          <<-HTML
+            <html>
+              <body></body>
+
+              <script>
+                setTimeout(function() {
+                  document.body.innerHTML = '<h1 id="test">Hey there</h1>';
+                }, 100);
+              </script>
+            </html>
+          HTML
+        end
+        let(:options) do
+          basic_header_footer_options.merge(
+            'waitForFunction' => 'document.getElementById("test") !== null'
+          )
+        end
+        let(:date) { Date.today.strftime '%-m/%-d/%Y' }
+
+        it { expect(pdf_text_content).to eq "#{date} Hey there http://www.example.net/foo/bar 1/1" }
+      end
+
       context 'when raise on request failure option is specified' do
         let(:options) { basic_header_footer_options.merge('raiseOnRequestFailure' => true) }
         let(:date) { Date.today.strftime '%-m/%-d/%Y' }
@@ -577,6 +601,31 @@ describe Grover::Processor do
         let(:date) { Date.today.strftime '%-m/%-d/%Y' }
 
         it { expect(pdf_text_content).to eq "#{date} http://www.example.net/foo/bar 1/1" }
+      end
+
+      context 'when wait for function option is specified with options' do
+        let(:url_or_html) do
+          <<-HTML
+            <html>
+              <body></body>
+
+              <script>
+                setTimeout(function() {
+                  document.body.innerHTML = '<h1 id="test">Hey there</h1>';
+                }, 500);
+              </script>
+            </html>
+          HTML
+        end
+        let(:options) do
+          basic_header_footer_options.merge(
+            'waitForFunction' => 'document.getElementById("test") !== null',
+            'waitForFunctionOptions' => { "polling": 50, "timeout": 750 }
+          )
+        end
+        let(:date) { Date.today.strftime '%-m/%-d/%Y' }
+
+        it { expect(pdf_text_content).to eq "#{date} Hey there http://www.example.net/foo/bar 1/1" }
       end
 
       # Only test `waitForTimeout` if the Puppeteer supports it

--- a/spec/grover/processor_spec.rb
+++ b/spec/grover/processor_spec.rb
@@ -626,6 +626,21 @@ describe Grover::Processor do
         let(:date) { Date.today.strftime '%-m/%-d/%Y' }
 
         it { expect(pdf_text_content).to eq "#{date} Hey there http://www.example.net/foo/bar 1/1" }
+
+        context 'when waiting for function takes too long' do
+          let(:options) do
+            basic_header_footer_options.merge(
+              'waitForFunction' => 'document.getElementById("test") !== null',
+              'waitForFunctionOptions' => { "polling": 50, "timeout": 250 }
+            )
+          end
+
+          it 'raises a JavaScript error if waitForFunction fails' do
+            expect do
+              pdf_text_content
+            end.to raise_error Grover::JavaScript::Error
+          end
+        end
       end
 
       # Only test `waitForTimeout` if the Puppeteer supports it


### PR DESCRIPTION
This PR adds support for waitForFunction & some relevant options.

My use case for this is when printing a page with Mapbox, it's good to wait until the map has loaded - there's not really a great way to handle this with the current wait variants. 

eg:
`page.waitForFunction("map.loaded()")`

I've added a couple of rspec tests for this functionality, and tested it properly on some pages with maps as well. Let me know if you have any thoughts!