### PR TITLE
Fix #121: stylesheets/images rendering with puppeteer v10.2.0

### DIFF
--- a/lib/grover/js/processor.js
+++ b/lib/grover/js/processor.js
@@ -145,11 +145,15 @@ const _processPage = (async (convertAction, urlOrHtml, options) => {
       // Request is some HTML content. Use request interception to assign the body
       requestOptions.waitUntil = waitUntil || 'networkidle0';
       await page.setRequestInterception(true);
-      page.once('request', async request => {
-        await request.respond({ body: urlOrHtml === '' ? ' ' : urlOrHtml });
-        // Reset the request interception
-        // (we only want to intercept the first request - ie our HTML)
-        await page.setRequestInterception(false);
+      let htmlIntercepted = false;
+      page.on('request', request => {
+        // We only want to intercept the first request - ie our HTML
+        if (htmlIntercepted)
+          request.continue();
+        else {
+          htmlIntercepted = true
+          request.respond({ body: urlOrHtml === '' ? ' ' : urlOrHtml });
+        }
       });
       const displayUrl = options.displayUrl; delete options.displayUrl;
       await page.goto(displayUrl || 'http://example.com', requestOptions);

--- a/lib/grover/js/processor.js
+++ b/lib/grover/js/processor.js
@@ -145,11 +145,11 @@ const _processPage = (async (convertAction, urlOrHtml, options) => {
       // Request is some HTML content. Use request interception to assign the body
       requestOptions.waitUntil = waitUntil || 'networkidle0';
       await page.setRequestInterception(true);
-      page.once('request', request => {
-        request.respond({ body: urlOrHtml === '' ? ' ' : urlOrHtml });
+      page.once('request', async request => {
+        await request.respond({ body: urlOrHtml === '' ? ' ' : urlOrHtml });
         // Reset the request interception
         // (we only want to intercept the first request - ie our HTML)
-        page.on('request', request => request.continue());
+        await page.setRequestInterception(false);
       });
       const displayUrl = options.displayUrl; delete options.displayUrl;
       await page.goto(displayUrl || 'http://example.com', requestOptions);


### PR DESCRIPTION
In puppeteer v10.2.0 they introduced changes to the way request interception handlers are processed:

- https://github.com/puppeteer/puppeteer/compare/v10.1.0...v10.2.0
- https://github.com/puppeteer/puppeteer/blob/c510df8d8e52fa361c26f6db011aaa9410c8996a/src/common/Page.ts#L627-L633

It caused a race condition in processing between two handlers (`page.once` and `page.on`). So I fixed this problem by properly awaiting response and disabling interception.