### PR TITLE
Fix error in processor.js when using the vision_deficiency option

### DIFF
--- a/lib/grover/js/processor.js
+++ b/lib/grover/js/processor.js
@@ -103,7 +103,7 @@ const _processPage = (async (convertAction, urlOrHtml, options) => {
     // Emulate vision deficiency (if provided)
     const visionDeficiency = options.visionDeficiency; delete options.visionDeficiency;
     if (visionDeficiency !== undefined) {
-      page.emulateVisionDeficiency(type);
+      page.emulateVisionDeficiency(visionDeficiency);
     }
 
     // Bypass CSP (content security policy), if provided

--- a/lib/grover/js/processor.js
+++ b/lib/grover/js/processor.js
@@ -91,7 +91,7 @@ const _processPage = (async (convertAction, urlOrHtml, options) => {
     // Emulate the media features, if specified
     const mediaFeatures = options.mediaFeatures; delete options.mediaFeatures;
     if (Array.isArray(mediaFeatures)) {
-      page.emulateMediaFeatures(mediaFeatures);
+      await page.emulateMediaFeatures(mediaFeatures);
     }
 
     // Emulate timezone (if provided)
@@ -100,28 +100,22 @@ const _processPage = (async (convertAction, urlOrHtml, options) => {
       await page.emulateTimezone(timezone);
     }
 
-    // Emulate vision deficiency (if provided)
-    const visionDeficiency = options.visionDeficiency; delete options.visionDeficiency;
-    if (visionDeficiency !== undefined) {
-      page.emulateVisionDeficiency(visionDeficiency);
-    }
-
     // Bypass CSP (content security policy), if provided
     const bypassCSP = options.bypassCSP; delete options.bypassCSP;
     if (bypassCSP !== undefined) {
-      page.setBypassCSP(bypassCSP);
+      await page.setBypassCSP(bypassCSP);
     }
 
     // Add extra HTTP headers (if provided)
     const extraHTTPHeaders = options.extraHTTPHeaders; delete options.extraHTTPHeaders;
     if (extraHTTPHeaders !== undefined) {
-      page.setExtraHTTPHeaders(extraHTTPHeaders);
+      await page.setExtraHTTPHeaders(extraHTTPHeaders);
     }
 
     // Set geolocation (if provided)
     const geolocation = options.geolocation; delete options.geolocation;
     if (geolocation !== undefined) {
-      page.setGeolocation(geolocation);
+      await page.setGeolocation(geolocation);
     }
 
     const raiseOnRequestFailure = options.raiseOnRequestFailure; delete options.raiseOnRequestFailure;
@@ -199,6 +193,12 @@ const _processPage = (async (convertAction, urlOrHtml, options) => {
     const waitForTimeout = options.waitForTimeout; delete options.waitForTimeout;
     if (waitForTimeout !== undefined) {
       await page.waitForTimeout(waitForTimeout);
+    }
+
+    // Emulate vision deficiency (if provided)
+    const visionDeficiency = options.visionDeficiency; delete options.visionDeficiency;
+    if (visionDeficiency !== undefined) {
+      await page.emulateVisionDeficiency(visionDeficiency);
     }
 
     // If specified, focus on the specified selector

--- a/spec/grover/processor_spec.rb
+++ b/spec/grover/processor_spec.rb
@@ -825,6 +825,19 @@ describe Grover::Processor do
         end
       end
 
+      # Only test `emulateVisionDeficiency` if the Puppeteer supports it
+      if puppeteer_version_on_or_after? '3.2.0'
+        context 'when vision deficiency is set to `deuteranopia`' do
+          let(:url_or_html) { '<html><body style="background-color: red"></body></html>' }
+          let(:options) { { 'visionDeficiency' => 'deuteranopia' } }
+
+          it { expect(convert.unpack('C*')).to start_with "\x89PNG\r\n\x1A\n".unpack('C*') }
+          it { expect(image.type).to eq 'PNG' }
+          it { expect(image.dimensions).to eq [800, 600] }
+          it { expect(mean_colour_statistics(image)).to eq %w[94 71 0] }
+        end
+      end
+
       context 'when specifying type of `png`' do
         let(:url_or_html) { '<html><body style="background-color: green"></body></html>' }
         let(:options) { { type: 'png' } }


### PR DESCRIPTION
Fixes the error in processor.js when using the vision_deficiency option as reported in issue #127.

Added a spec as you suggested, but I'm running into some strange behavior. On some test runs the mean_colour_statistics returns ["94", "71", "0"] (which I assume is correct) on other runs it returns ["240.506", "240.527", "242.569"]. This is likely the mean color from the page http://www.example.net/foo/bar. Do you recognize this inconsistency while running the specs?

```  
1) Grover::Processor#convert when converting to an image when vision deficiency is set to `deuteranopia` is expected to eq ["94", "71", "0"]
  Failure/Error: it { expect(mean_colour_statistics(image)).to eq %w[94 71 0] }
  
    expected: ["94", "71", "0"]
        got: ["240.506", "240.527", "242.569"]
  
    (compared using ==)
  # ./spec/grover/processor_spec.rb:837:in `block (5 levels) in <top (required)>'
```