### PR TITLE
Use Focal build containers instead of Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: focal
+
 env:
   global:
     - CC_TEST_REPORTER_ID=5cfed40102c670b5c9e509730782b751939ddbe53fc57c317b718f635bab1ce8


### PR DESCRIPTION
RVM installs are dying because of certificate issues with Let's Encrypt.