### PR TITLE
Add support for `request_timeout` and `convert_timeout` options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,18 +13,20 @@ env:
     - PUPPETEER_VERSION=7.1.0
     - PUPPETEER_VERSION=8.0.0
     - PUPPETEER_VERSION=9.1.1
-    - PUPPETEER_VERSION=10.2.0
+    - PUPPETEER_VERSION=10.4.0
+    - PUPPETEER_VERSION=11.0.0
+    - PUPPETEER_VERSION=12.0.1
 
 rvm: 3.0
 
 jobs:
   include:
     - rvm: 2.5
-      env: PUPPETEER_VERSION=10.2.0
+      env: PUPPETEER_VERSION=12.0.1
     - rvm: 2.6
-      env: PUPPETEER_VERSION=10.2.0
+      env: PUPPETEER_VERSION=12.0.1
     - rvm: 2.7
-      env: PUPPETEER_VERSION=10.2.0
+      env: PUPPETEER_VERSION=12.0.1
 
 language: ruby
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
 ## Unreleased
-- none
+### Breaking Change
+- [#144](https://github.com/Studiosity/grover/pull/144) Add support for `request_timeout` and `convert_timeout` options (`timeout` option applies to conversion for Puppeteer 10.4.0+) ([@abrom][])
 
 ## [1.0.6](releases/tag/v1.0.6) - 2021-10-12
-[#131](https://github.com/Studiosity/grover/pull/131) Add support for ignoring request in addition to request.path ([@braindeaf][])
+### Added
+- [#131](https://github.com/Studiosity/grover/pull/131) Add support for ignoring request in addition to request.path ([@braindeaf][])
 
 ## [1.0.5](releases/tag/v1.0.5) - 2021-08-30
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 ### Breaking Change
-- [#144](https://github.com/Studiosity/grover/pull/144) Add support for `request_timeout` and `convert_timeout` options (`timeout` option applies to conversion for Puppeteer 10.4.0+) ([@abrom][])
+- [#145](https://github.com/Studiosity/grover/pull/145) Add support for `request_timeout` and `convert_timeout` options (`timeout` option applies to conversion for Puppeteer 10.4.0+) ([@abrom][])
 
 ## [1.0.6](releases/tag/v1.0.6) - 2021-10-12
 ### Added

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ Grover can be configured to adjust the layout of the resulting PDF/image.
 
 For available PDF options, see https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pagepdfoptions
 
-Also available are the `emulate_media`, `cache`, `viewport`, `timeout` and `launch_args` options.
+Also available are the `emulate_media`, `cache`, `viewport`, `timeout`, `requestTimeout`, `convertTimeout`
+and `launch_args` options.
 
 ```ruby
 # config/initializers/grover.rb
@@ -109,12 +110,14 @@ Grover.configure do |config|
     media_features: [{ name: 'prefers-color-scheme', value: 'dark' }],
     timezone: 'Australia/Sydney',
     vision_deficiency: 'deuteranopia',
-    extraHTTPHeaders: { 'Accept-Language': 'en-US' },
+    extra_http_headers: { 'Accept-Language': 'en-US' },
     geolocation: { latitude: 59.95, longitude: 30.31667 },
     focus: '#some-element',
     hover: '#another-element',
     cache: false,
     timeout: 0, # Timeout in ms. A value of `0` means 'no timeout'
+    request_timeout: 1000, # Timeout when fetching the content (overloads the `timeout` option)
+    convert_timeout: 2000, # Timeout when converting the content (overloads the `timeout` option, only applies to PDF conversion)
     launch_args: ['--font-render-hinting=medium'],
     wait_until: 'domcontentloaded'
   }

--- a/lib/grover/js/processor.js
+++ b/lib/grover/js/processor.js
@@ -61,9 +61,10 @@ const _processPage = (async (convertAction, urlOrHtml, options) => {
 
     // Setup timeout option (if provided)
     let requestOptions = {};
-    const timeout = options.timeout; delete options.timeout;
-    if (timeout !== undefined) {
-      requestOptions.timeout = timeout;
+    let requestTimeout = options.requestTimeout; delete options.requestTimeout;
+    if (requestTimeout === undefined) requestTimeout = options.timeout;
+    if (requestTimeout !== undefined) {
+      requestOptions.timeout = requestTimeout;
     }
 
     // Setup user agent (if provided)
@@ -121,7 +122,7 @@ const _processPage = (async (convertAction, urlOrHtml, options) => {
     const raiseOnRequestFailure = options.raiseOnRequestFailure; delete options.raiseOnRequestFailure;
     if (raiseOnRequestFailure) {
       page.on('requestfinished', (request) => {
-        if (request.response() && !(request.response().ok() || request.response().status() == 304) && !request.redirectChain().length > 0) {
+        if (request.response() && !(request.response().ok() || request.response().status() === 304) && !request.redirectChain().length > 0) {
           errors.push(request);
         }
       });
@@ -228,6 +229,12 @@ const _processPage = (async (convertAction, urlOrHtml, options) => {
       }
       RequestFailedError.prototype = Error.prototype;
       throw new RequestFailedError(errors);
+    }
+
+    // Setup conversion timeout
+    if (options.convertTimeout !== undefined) {
+      options.timeout = options.convertTimeout;
+      delete options.convertTimeout;
     }
 
     // If we're running puppeteer in headless mode, return the converted PDF

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   },
   "homepage": "https://github.com/Studiosity/grover#readme",
   "devDependencies": {
-    "puppeteer": "^10.2.0"
+    "puppeteer": "^12.0.1"
   }
 }

--- a/spec/grover/processor_spec.rb
+++ b/spec/grover/processor_spec.rb
@@ -745,7 +745,7 @@ describe Grover::Processor do
         end
 
         context 'when the timeout is long' do
-          let(:timeout) { 5000 }
+          let(:timeout) { 10_000 }
 
           it { is_expected.to start_with "%PDF-1.4\n" }
         end
@@ -761,14 +761,14 @@ describe Grover::Processor do
           it_behaves_like 'raises navigation timeout error'
 
           context 'when the timeout is also specified' do
-            let(:timeout) { 5000 }
+            let(:timeout) { 10_000 }
 
             it_behaves_like 'raises navigation timeout error'
           end
         end
 
         context 'when the request timeout is long' do
-          let(:request_timeout) { 5000 }
+          let(:request_timeout) { 10_000 }
 
           it { is_expected.to start_with "%PDF-1.4\n" }
 
@@ -808,7 +808,7 @@ describe Grover::Processor do
           end
 
           context 'when the timeout is also specified' do
-            let(:timeout) { 5000 }
+            let(:timeout) { 10_000 }
 
             if puppeteer_version_on_or_after? '10.4.0'
               it 'will use the convert timeout over the timeout option' do
@@ -824,7 +824,7 @@ describe Grover::Processor do
         end
 
         context 'when the convert timeout is long' do
-          let(:convert_timeout) { 5000 }
+          let(:convert_timeout) { 10_000 }
 
           it { is_expected.to start_with "%PDF-1.4\n" }
 

--- a/spec/grover/processor_spec.rb
+++ b/spec/grover/processor_spec.rb
@@ -831,16 +831,7 @@ describe Grover::Processor do
           context 'when the timeout is also specified (but something much smaller than the convert timeout)' do
             let(:timeout) { 1 }
 
-            if puppeteer_version_on_or_after? '10.4.0'
-              it 'will timeout when converting to PDF' do
-                expect { convert }.to raise_error(
-                  Grover::JavaScript::TimeoutError,
-                  'waiting for Page.printToPDF failed: timeout 1ms exceeded'
-                )
-              end
-            else
-              it { is_expected.to start_with "%PDF-1.4\n" }
-            end
+            it_behaves_like 'raises navigation timeout error'
           end
         end
       end

--- a/spec/grover/processor_spec.rb
+++ b/spec/grover/processor_spec.rb
@@ -720,23 +720,23 @@ describe Grover::Processor do
         end
       end
 
-      context 'when timeout option is specified' do
-        let(:options) { basic_header_footer_options.merge('timeout' => timeout) }
-
-        shared_examples 'raises navigation timeout error' do
-          if puppeteer_version_on_or_after? '2.0.0'
-            it do
-              expect { convert }.to raise_error Grover::JavaScript::TimeoutError, 'Navigation timeout of 1 ms exceeded'
-            end
-          else
-            it do
-              expect { convert }.to raise_error(
-                Grover::JavaScript::TimeoutError,
-                'Navigation Timeout Exceeded: 1ms exceeded'
-              )
-            end
+      shared_examples 'raises navigation timeout error' do
+        if puppeteer_version_on_or_after? '2.0.0'
+          it do
+            expect { convert }.to raise_error Grover::JavaScript::TimeoutError, 'Navigation timeout of 1 ms exceeded'
+          end
+        else
+          it do
+            expect { convert }.to raise_error(
+              Grover::JavaScript::TimeoutError,
+              'Navigation Timeout Exceeded: 1ms exceeded'
+            )
           end
         end
+      end
+
+      context 'when timeout option is specified' do
+        let(:options) { basic_header_footer_options.merge('timeout' => timeout) }
 
         context 'when the timeout is short' do
           let(:timeout) { 1 }

--- a/spec/grover/processor_spec.rb
+++ b/spec/grover/processor_spec.rb
@@ -768,9 +768,9 @@ describe Grover::Processor do
 
             it 'will timeout when trying to convert to PDF' do
               expect { convert }.to raise_error(
-                                      Grover::JavaScript::TimeoutError,
-                                      'waiting for Page.printToPDF failed: timeout 1ms exceeded'
-                                    )
+                Grover::JavaScript::TimeoutError,
+                'waiting for Page.printToPDF failed: timeout 1ms exceeded'
+              )
             end
           end
         end
@@ -787,9 +787,9 @@ describe Grover::Processor do
 
             it 'will raise an error when trying to convert to PDF' do
               expect { convert }.to raise_error(
-                                      Grover::JavaScript::TimeoutError,
-                                      'waiting for Page.printToPDF failed: timeout 1ms exceeded'
-                                    )
+                Grover::JavaScript::TimeoutError,
+                'waiting for Page.printToPDF failed: timeout 1ms exceeded'
+              )
             end
 
             context 'when the timeout is also specified' do
@@ -797,9 +797,9 @@ describe Grover::Processor do
 
               it 'will use the convert timeout over the timeout option' do
                 expect { convert }.to raise_error(
-                                        Grover::JavaScript::TimeoutError,
-                                        'waiting for Page.printToPDF failed: timeout 1ms exceeded'
-                                      )
+                  Grover::JavaScript::TimeoutError,
+                  'waiting for Page.printToPDF failed: timeout 1ms exceeded'
+                )
               end
             end
           end
@@ -814,9 +814,9 @@ describe Grover::Processor do
 
               it 'will timeout when converting to PDF' do
                 expect { convert }.to raise_error(
-                                        Grover::JavaScript::TimeoutError,
-                                        'waiting for Page.printToPDF failed: timeout 1ms exceeded'
-                                      )
+                  Grover::JavaScript::TimeoutError,
+                  'waiting for Page.printToPDF failed: timeout 1ms exceeded'
+                )
               end
             end
           end


### PR DESCRIPTION
Puppeteer 10.4.0 added support for a PDF conversion timeout (default 30,000ms). This change will use the existing `timeout` option to apply to both the request and convert phases, but also adds `request_timeout` and `convert_timeout` options that can be used to overload `timeout`.