### PR TITLE
Ruby 3.1 compatibility

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ require: rubocop-rspec
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
 
 Layout/DotPosition:
   EnforcedStyle: trailing

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,15 @@ env:
     - PUPPETEER_VERSION=11.0.0
     - PUPPETEER_VERSION=12.0.1
 
-rvm: 3.0
+rvm: 3.1.0
 
 jobs:
   include:
-    - rvm: 2.5
-      env: PUPPETEER_VERSION=12.0.1
     - rvm: 2.6
       env: PUPPETEER_VERSION=12.0.1
     - rvm: 2.7
+      env: PUPPETEER_VERSION=12.0.1
+    - rvm: 3.0
       env: PUPPETEER_VERSION=12.0.1
 
 language: ruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     - PUPPETEER_VERSION=11.0.0
     - PUPPETEER_VERSION=12.0.1
 
-rvm: 3.1.0
+rvm: 3.0
 
 jobs:
   include:
@@ -25,7 +25,7 @@ jobs:
       env: PUPPETEER_VERSION=12.0.1
     - rvm: 2.7
       env: PUPPETEER_VERSION=12.0.1
-    - rvm: 3.0
+    - rvm: ruby-head
       env: PUPPETEER_VERSION=12.0.1
 
 language: ruby

--- a/grover.gemspec
+++ b/grover.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   SUMMARY
   spec.homepage    = 'https://github.com/Studiosity/grover'
   spec.license     = 'MIT'
-  spec.required_ruby_version = ['>= 2.5.0', '< 3.1.0']
+  spec.required_ruby_version = ['>= 2.5.0', '< 3.2.0']
 
   spec.files         = `git ls-files lib`.split("\n") + ['LICENSE']
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/grover.gemspec
+++ b/grover.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   SUMMARY
   spec.homepage    = 'https://github.com/Studiosity/grover'
   spec.license     = 'MIT'
-  spec.required_ruby_version = ['>= 2.5.0', '< 3.2.0']
+  spec.required_ruby_version = ['>= 2.6.0', '< 3.2.0']
 
   spec.files         = `git ls-files lib`.split("\n") + ['LICENSE']
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
Ruby 3.1's release is around the corner and grover seems to work just fine with the Ruby 3.1.0-preview1. Specs all pass.