### PR TITLE
Update link to PDF options docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ page content and devtools.
 ## Configuration
 Grover can be configured to adjust the layout of the resulting PDF/image.
 
-For available PDF options, see https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pagepdfoptions
+For available PDF options, see https://github.com/puppeteer/puppeteer/blob/1fbc3c643f31f529597f8ae562959b15e9baa1c5/docs/api/puppeteer.pdfoptions.md
 
 Also available are the `emulate_media`, `cache`, `viewport`, `timeout`, `requestTimeout`, `convertTimeout`
 and `launch_args` options.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ page content and devtools.
 ## Configuration
 Grover can be configured to adjust the layout of the resulting PDF/image.
 
-For available PDF options, see https://github.com/puppeteer/puppeteer/blob/1fbc3c643f31f529597f8ae562959b15e9baa1c5/docs/api/puppeteer.pdfoptions.md
+For available PDF options, see https://github.com/puppeteer/puppeteer/blob/main/docs/api/puppeteer.pdfoptions.md
 
 Also available are the `emulate_media`, `cache`, `viewport`, `timeout`, `requestTimeout`, `convertTimeout`
 and `launch_args` options.


### PR DESCRIPTION
Hi 👋 

First off, thanks for the awesome work on that tool 💚 Love it so far, exactly what I was looking for.

This PR is just a small drive-by fix while reading the docs: The link to Puppeteer's documentation on PDF options was no longer working. I replaced it with a permalink to (what I think is) the respective document in the Puppeteer repo.