### PR TITLE
Ruby `3.2.0` compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,6 @@ jobs:
           PUPPETEER_VERSION: ${{ matrix.puppeteer-version }}
 
       - name: Test & publish code coverage
-        uses: paambaati/codeclimate-action@v3
+        uses: paambaati/codeclimate-action@v3.2.0
         env:
           CC_TEST_REPORTER_ID: 5cfed40102c670b5c9e509730782b751939ddbe53fc57c317b718f635bab1ce8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,52 +12,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.1']
-        node-version: ['10']
-        puppeteer-version: [
-            '1.20.0',
-            '2.1.1',
-            '3.3.0',
-            '4.0.1',
-            '5.5.0',
-            '6.0.0',
-            '7.1.0',
-            '8.0.0',
-            '9.1.1',
-            '10.4.0',
-            '11.0.0',
-            '12.0.1',
-            '13.7.0',
-            '14.4.1',
-            '15.5.0',
-            '16.2.0',
-            '17.1.3'
-        ]
+        ruby-version: ['3.2']
+        node-version: ['14', '16', '18']
+        puppeteer-version: ['14.4.1', '15.5.0', '16.2.0', '17.1.3', '18.2.1', '19.4.1']
         include:
-          - ruby-version: '2.6'
-            node-version: '10'
-            puppeteer-version: '17.1.3'
-          - ruby-version: '2.7'
-            node-version: '10'
-            puppeteer-version: '17.1.3'
-          - ruby-version: '3.0'
-            node-version: '10'
-            puppeteer-version: '17.1.3'
-          - ruby-version: '3.1'
-            node-version: '12'
-            puppeteer-version: '17.1.3'
           - ruby-version: '3.1'
             node-version: '14'
-            puppeteer-version: '17.1.3'
-          - ruby-version: '3.1'
-            node-version: '16'
-            puppeteer-version: '17.1.3'
-          - ruby-version: '3.1'
-            node-version: '18'
-            puppeteer-version: '17.1.3'
+            puppeteer-version: '19.4.1'
+          - ruby-version: '3.0'
+            node-version: '14'
+            puppeteer-version: '19.4.1'
+          - ruby-version: '2.7'
+            node-version: '14'
+            puppeteer-version: '19.4.1'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -66,7 +36,7 @@ jobs:
           bundler-cache: true
 
       - name: Set up Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -82,6 +52,6 @@ jobs:
           PUPPETEER_VERSION: ${{ matrix.puppeteer-version }}
 
       - name: Test & publish code coverage
-        uses: paambaati/codeclimate-action@v3.0.0
+        uses: paambaati/codeclimate-action@v3
         env:
           CC_TEST_REPORTER_ID: 5cfed40102c670b5c9e509730782b751939ddbe53fc57c317b718f635bab1ce8

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ require: rubocop-rspec
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 Layout/DotPosition:
   EnforcedStyle: trailing

--- a/grover.gemspec
+++ b/grover.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'grover/version'
 
-Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
+Gem::Specification.new do |spec|
   spec.name        = 'grover'
   spec.version     = Grover::VERSION
   spec.authors     = ['Andrew Bromwich']
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   SUMMARY
   spec.homepage    = 'https://github.com/Studiosity/grover'
   spec.license     = 'MIT'
-  spec.required_ruby_version = ['>= 2.6.0', '< 3.2.0']
+  spec.required_ruby_version = ['>= 2.7.0', '< 3.3.0']
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
 
   spec.files         = `git ls-files lib`.split("\n") + ['LICENSE']
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ['lib']
 
   spec.add_dependency 'combine_pdf', '~> 1.0'
@@ -36,10 +35,10 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.add_development_dependency 'mini_magick', '~> 4.9'
   spec.add_development_dependency 'pdf-reader', '~> 2.2'
   spec.add_development_dependency 'rack-test', '~> 1.1'
-  spec.add_development_dependency 'rake', '~> 12.3'
+  spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.8'
-  spec.add_development_dependency 'rubocop', '~> 0.72'
-  spec.add_development_dependency 'rubocop-rspec', '~> 1.33'
+  spec.add_development_dependency 'rubocop', '~> 1.41'
+  spec.add_development_dependency 'rubocop-rspec', '~> 2.16'
   # Limit simplecov to 0.17.x due to https://github.com/codeclimate/test-reporter/issues/413
   spec.add_development_dependency 'simplecov', '~> 0.17', '< 0.18'
 end

--- a/lib/active_support_ext/object/duplicable.rb
+++ b/lib/active_support_ext/object/duplicable.rb
@@ -31,122 +31,33 @@ class Object
   end
 end
 
-class NilClass
-  begin
-    nil.dup
-  rescue TypeError
-    # +nil+ is not duplicable:
-    #
-    #   nil.duplicable? # => false
-    #   nil.dup         # => TypeError: can't dup NilClass
-    def duplicable?
-      false
-    end
-  end
-end
-
-class FalseClass
-  begin
-    false.dup
-  rescue TypeError
-    # +false+ is not duplicable:
-    #
-    #   false.duplicable? # => false
-    #   false.dup         # => TypeError: can't dup FalseClass
-    def duplicable?
-      false
-    end
-  end
-end
-
-class TrueClass
-  begin
-    true.dup
-  rescue TypeError
-    # +true+ is not duplicable:
-    #
-    #   true.duplicable? # => false
-    #   true.dup         # => TypeError: can't dup TrueClass
-    def duplicable?
-      false
-    end
-  end
-end
-
-class Symbol
-  begin
-    :symbol.dup # Ruby 2.4.x.
-    'symbol_from_string'.to_sym.dup # Some symbols can't `dup` in Ruby 2.4.0.
-  rescue TypeError
-    # Symbols are not duplicable:
-    #
-    #   :my_symbol.duplicable? # => false
-    #   :my_symbol.dup         # => TypeError: can't dup Symbol
-    def duplicable?
-      false
-    end
-  end
-end
-
-class Numeric
-  begin
-    1.dup
-  rescue TypeError
-    # Numbers are not duplicable:
-    #
-    #  3.duplicable? # => false
-    #  3.dup         # => TypeError: can't dup Integer
-    def duplicable?
-      false
-    end
-  end
-end
-
-require 'bigdecimal'
-class BigDecimal
-  # BigDecimals are duplicable:
-  #
-  #   BigDecimal("1.2").duplicable? # => true
-  #   BigDecimal("1.2").dup         # => #<BigDecimal:...,'0.12E1',18(18)>
-  def duplicable?
-    true
-  end
-end
-
 class Method
   # Methods are not duplicable:
   #
-  #  method(:puts).duplicable? # => false
-  #  method(:puts).dup         # => TypeError: allocator undefined for Method
+  #   method(:puts).duplicable? # => false
+  #   method(:puts).dup         # => TypeError: allocator undefined for Method
   def duplicable?
     false
   end
 end
 
-class Complex
-  begin
-    Complex(1).dup
-  rescue TypeError
-    # Complexes are not duplicable:
-    #
-    #   Complex(1).duplicable? # => false
-    #   Complex(1).dup         # => TypeError: can't copy Complex
-    def duplicable?
-      false
-    end
+class UnboundMethod
+  # Unbound methods are not duplicable:
+  #
+  #   method(:puts).unbind.duplicable? # => false
+  #   method(:puts).unbind.dup         # => TypeError: allocator undefined for UnboundMethod
+  def duplicable?
+    false
   end
 end
 
-class Rational
-  begin
-    Rational(1).dup
-  rescue TypeError
-    # Rationals are not duplicable:
-    #
-    #   Rational(1).duplicable? # => false
-    #   Rational(1).dup         # => TypeError: can't copy Rational
-    def duplicable?
-      false
-    end
+require 'singleton'
+
+module Singleton
+  # Singleton instances are not duplicable:
+  #
+  #   Class.new.include(Singleton).instance.dup # TypeError (can't dup instance of singleton
+  def duplicable?
+    false
   end
 end

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   },
   "homepage": "https://github.com/Studiosity/grover#readme",
   "devDependencies": {
-    "puppeteer": "^17.1.3"
+    "puppeteer": "^19.4.1"
   }
 }

--- a/spec/active_support_ext/object/deep_dup_spec.rb
+++ b/spec/active_support_ext/object/deep_dup_spec.rb
@@ -8,8 +8,8 @@ describe 'DeepDup' do
       object = Object.new
       dup = object.deep_dup
       dup.instance_variable_set(:@a, 1)
-      expect(object.instance_variable_defined?(:@a)).to eq false
-      expect(dup.instance_variable_defined?(:@a)).to eq true
+      expect(object.instance_variable_defined?(:@a)).to be false
+      expect(dup.instance_variable_defined?(:@a)).to be true
     end
   end
 

--- a/spec/grover/processor_spec.rb
+++ b/spec/grover/processor_spec.rb
@@ -11,9 +11,7 @@ describe Grover::Processor do
     let(:url_or_html) { 'http://google.com' }
     let(:options) { {} }
     let(:date) do
-      # New version of Chromium (v93) that comes with v10.2.0 of puppeteer uses a different date format
-      date_format = puppeteer_version_on_or_after?('10.2.0') ? '%-m/%-d/%y, %-l:%M %p' : '%-m/%-d/%Y'
-      Time.now.strftime date_format
+      Time.now.strftime '%-m/%-d/%y, %-l:%M %p'
     end
 
     context 'when converting to PDF' do
@@ -364,40 +362,41 @@ describe Grover::Processor do
           end
         end
 
-        #   context 'when passing through cookies option' do
-        #     let(:url_or_html) { 'https://cookie-renderer.herokuapp.com/' }
-        #     let(:options) do
-        #       {
-        #         'cookies' => [
-        #           { 'name' => 'grover-test', 'value' => 'nom nom nom', 'domain' => 'cookie-renderer.herokuapp.com' },
-        #           { 'name' => 'other-domain', 'value' => 'should not display', 'domain' => 'example.com' },
-        #           { 'name' => 'escaped', 'value' => '%26%3D%3D', 'domain' => 'cookie-renderer.herokuapp.com' }
-        #         ]
-        #       }
-        #     end
-        #
-        #     it { expect(pdf_text_content).to include 'Request contained 2 cookies' }
-        #     it { expect(pdf_text_content).to include '1. grover-test nom nom nom' }
-        #     it { expect(pdf_text_content).to include '2. escaped &==' }
-        #   end
-        #
-        #   context 'when passing through extra HTTP headers' do
-        #     let(:url_or_html) { 'http://cookie-renderer.herokuapp.com/?type=headers' }
-        #     let(:options) { { 'extraHTTPHeaders' => { 'grover-test' => 'yes it is' } } }
-        #
-        #     it { expect(pdf_text_content).to match(/Request contained (15|16) headers/) }
-        #     it { expect(pdf_text_content).to include '1. host cookie-renderer.herokuapp.com' }
-        #     it { expect(pdf_text_content).to include '5. grover-test yes it is' }
-        #   end
-        #
-        #   context 'when overloading the user agent' do
-        #     let(:url_or_html) { 'http://cookie-renderer.herokuapp.com/?type=headers' }
-        #     let(:options) { { 'userAgent' => 'Grover user agent' } }
-        #
-        #     it { expect(pdf_text_content).to match(/Request contained (14|15) headers/) }
-        #     it { expect(pdf_text_content).to include '1. host cookie-renderer.herokuapp.com' }
-        #     it { expect(pdf_text_content).to include 'user-agent Grover user agent' }
-        #   end
+        # TODO: Replace cookie renderer app
+        context 'when passing through cookies option' do
+          let(:url_or_html) { 'https://cookie-renderer.herokuapp.com/' }
+          let(:options) do
+            {
+              'cookies' => [
+                { 'name' => 'grover-test', 'value' => 'nom nom nom', 'domain' => 'cookie-renderer.herokuapp.com' },
+                { 'name' => 'other-domain', 'value' => 'should not display', 'domain' => 'example.com' },
+                { 'name' => 'escaped', 'value' => '%26%3D%3D', 'domain' => 'cookie-renderer.herokuapp.com' }
+              ]
+            }
+          end
+
+          it { expect(pdf_text_content).to include 'Request contained 2 cookies' }
+          it { expect(pdf_text_content).to include '1. grover-test nom nom nom' }
+          it { expect(pdf_text_content).to include '2. escaped &==' }
+        end
+
+        context 'when passing through extra HTTP headers' do
+          let(:url_or_html) { 'http://cookie-renderer.herokuapp.com/?type=headers' }
+          let(:options) { { 'extraHTTPHeaders' => { 'grover-test' => 'yes it is' } } }
+
+          it { expect(pdf_text_content).to match(/Request contained (15|16) headers/) }
+          it { expect(pdf_text_content).to include '1. host cookie-renderer.herokuapp.com' }
+          it { expect(pdf_text_content).to include '5. grover-test yes it is' }
+        end
+
+        context 'when overloading the user agent' do
+          let(:url_or_html) { 'http://cookie-renderer.herokuapp.com/?type=headers' }
+          let(:options) { { 'userAgent' => 'Grover user agent' } }
+
+          it { expect(pdf_text_content).to match(/Request contained (14|15) headers/) }
+          it { expect(pdf_text_content).to include '1. host cookie-renderer.herokuapp.com' }
+          it { expect(pdf_text_content).to include 'user-agent Grover user agent' }
+        end
       end
 
       context 'when HTML includes screen only content' do
@@ -428,11 +427,9 @@ describe Grover::Processor do
         end
       end
 
-      # Only test `emulateMediaFeatures` if the Puppeteer supports it
-      if puppeteer_version_on_or_after? '2.0.0'
-        context 'when the browser timezone is rendered' do
-          let(:url_or_html) do
-            <<-HTML
+      context 'when the browser timezone is rendered' do
+        let(:url_or_html) do
+          <<-HTML
               <html>
                 <body>
                   Timezone offset is
@@ -440,22 +437,21 @@ describe Grover::Processor do
                   <script>document.getElementById("timezone").innerHTML = new Date().getTimezoneOffset();</script>
                 </body>
               </html>
-            HTML
-          end
+          HTML
+        end
 
-          it { expect(pdf_text_content).to eq "Timezone offset is #{Time.now.utc_offset / -60}" }
+        it { expect(pdf_text_content).to eq "Timezone offset is #{Time.now.utc_offset / -60}" }
 
-          context 'when timezone is overridden with Brisbane' do
-            let(:options) { { 'timezone' => 'Australia/Brisbane' } }
+        context 'when timezone is overridden with Brisbane' do
+          let(:options) { { 'timezone' => 'Australia/Brisbane' } }
 
-            it { expect(pdf_text_content).to eq 'Timezone offset is -600' }
-          end
+          it { expect(pdf_text_content).to eq 'Timezone offset is -600' }
+        end
 
-          context 'when timezone is overridden with Dhaka' do
-            let(:options) { { 'timezone' => 'Asia/Dhaka' } }
+        context 'when timezone is overridden with Dhaka' do
+          let(:options) { { 'timezone' => 'Asia/Dhaka' } }
 
-            it { expect(pdf_text_content).to eq 'Timezone offset is -360' }
-          end
+          it { expect(pdf_text_content).to eq 'Timezone offset is -360' }
         end
       end
 
@@ -659,11 +655,9 @@ describe Grover::Processor do
         it { expect(pdf_text_content).to eq "#{date} http://www.example.net/foo/bar 1/1" }
       end
 
-      # Only test `waitForTimeout` if the Puppeteer supports it
-      if puppeteer_version_on_or_after? '5.3.0'
-        context 'when waitForTimeout option is specified' do
-          let(:url_or_html) do
-            <<-HTML
+      context 'when waitForTimeout option is specified' do
+        let(:url_or_html) do
+          <<-HTML
               <html>
                 <body>
                   <p id="loading">Loading</p>
@@ -677,17 +671,16 @@ describe Grover::Processor do
                   }, 100);
                 </script>
               </html>
-            HTML
-          end
-          let(:options) { { 'waitUntil' => 'load' } }
+          HTML
+        end
+        let(:options) { { 'waitUntil' => 'load' } }
 
-          it { expect(pdf_text_content).to eq 'Loading' }
+        it { expect(pdf_text_content).to eq 'Loading' }
 
-          context 'when waiting for the content load timeout to occur' do
-            let(:options) { { 'waitForTimeout' => 200, 'waitUntil' => 'load' } }
+        context 'when waiting for the content load timeout to occur' do
+          let(:options) { { 'waitForTimeout' => 200, 'waitUntil' => 'load' } }
 
-            it { expect(pdf_text_content).to eq 'Loaded' }
-          end
+          it { expect(pdf_text_content).to eq 'Loaded' }
         end
       end
 
@@ -725,17 +718,8 @@ describe Grover::Processor do
       end
 
       shared_examples 'raises navigation timeout error' do
-        if puppeteer_version_on_or_after? '2.0.0'
-          it do
-            expect { convert }.to raise_error Grover::JavaScript::TimeoutError, 'Navigation timeout of 1 ms exceeded'
-          end
-        else
-          it do
-            expect { convert }.to raise_error(
-              Grover::JavaScript::TimeoutError,
-              'Navigation Timeout Exceeded: 1ms exceeded'
-            )
-          end
+        it do
+          expect { convert }.to raise_error Grover::JavaScript::TimeoutError, 'Navigation timeout of 1 ms exceeded'
         end
       end
 
@@ -779,15 +763,11 @@ describe Grover::Processor do
           context 'when the timeout is also specified (but something much smaller than the request timeout)' do
             let(:timeout) { 1 }
 
-            if puppeteer_version_on_or_after? '10.4.0'
-              it 'will timeout when trying to convert to PDF' do
-                expect { convert }.to raise_error(
-                  Grover::JavaScript::TimeoutError,
-                  'waiting for Page.printToPDF failed: timeout 1ms exceeded'
-                )
-              end
-            else
-              it { is_expected.to start_with "%PDF-1.4\n" }
+            it 'will timeout when trying to convert to PDF' do
+              expect { convert }.to raise_error(
+                Grover::JavaScript::TimeoutError,
+                'waiting for Page.printToPDF failed: timeout 1ms exceeded'
+              )
             end
           end
         end
@@ -800,29 +780,21 @@ describe Grover::Processor do
         context 'when the convert timeout is short' do
           let(:convert_timeout) { 1 }
 
-          if puppeteer_version_on_or_after? '10.4.0'
-            it 'will raise an error when trying to convert to PDF' do
-              expect { convert }.to raise_error(
-                Grover::JavaScript::TimeoutError,
-                'waiting for Page.printToPDF failed: timeout 1ms exceeded'
-              )
-            end
-          else
-            it { is_expected.to start_with "%PDF-1.4\n" }
+          it 'will raise an error when trying to convert to PDF' do
+            expect { convert }.to raise_error(
+              Grover::JavaScript::TimeoutError,
+              'waiting for Page.printToPDF failed: timeout 1ms exceeded'
+            )
           end
 
           context 'when the timeout is also specified' do
             let(:timeout) { 10_000 }
 
-            if puppeteer_version_on_or_after? '10.4.0'
-              it 'will use the convert timeout over the timeout option' do
-                expect { convert }.to raise_error(
-                  Grover::JavaScript::TimeoutError,
-                  'waiting for Page.printToPDF failed: timeout 1ms exceeded'
-                )
-              end
-            else
-              it { is_expected.to start_with "%PDF-1.4\n" }
+            it 'will use the convert timeout over the timeout option' do
+              expect { convert }.to raise_error(
+                Grover::JavaScript::TimeoutError,
+                'waiting for Page.printToPDF failed: timeout 1ms exceeded'
+              )
             end
           end
         end
@@ -913,55 +885,44 @@ describe Grover::Processor do
         it { expect(mean_colour_statistics(image)).to eq %w[165 42 42] }
       end
 
-      # Only test `emulateMediaFeatures` if the Puppeteer supports it
-      if puppeteer_version_on_or_after? '2.0.0'
-        context 'when passing through `media_features` options' do
-          let(:url_or_html) do
-            <<~HTML
-              <html>
-                <head>
-                  <style>
-                    body { background-color: red; }
-                    @media (prefers-color-scheme: light) {
-                      body { background-color: green; }
-                    }
-                    @media (prefers-color-scheme: dark) {
-                      body { background-color: blue; }
-                    }
-                  </style>
-                </head>
-                <body></body>
-              </html>
-            HTML
-          end
-          let(:options) do
-            { path: 'foo.png', 'mediaFeatures' => [{ 'name' => 'prefers-color-scheme', 'value' => 'dark' }] }
-          end
-
-          it { expect(convert.unpack('C*')).to start_with "\x89PNG\r\n\x1A\n".unpack('C*') }
-          it { expect(image.type).to eq 'PNG' }
-          it { expect(image.dimensions).to eq [800, 600] }
-          it { expect(mean_colour_statistics(image)).to eq %w[0 0 255] }
+      context 'when passing through `media_features` options' do
+        let(:url_or_html) do
+          <<~HTML
+            <html>
+              <head>
+                <style>
+                  body { background-color: red; }
+                  @media (prefers-color-scheme: light) {
+                    body { background-color: green; }
+                  }
+                  @media (prefers-color-scheme: dark) {
+                    body { background-color: blue; }
+                  }
+                </style>
+              </head>
+              <body></body>
+            </html>
+          HTML
         end
+        let(:options) do
+          { path: 'foo.png', 'mediaFeatures' => [{ 'name' => 'prefers-color-scheme', 'value' => 'dark' }] }
+        end
+
+        it { expect(convert.unpack('C*')).to start_with "\x89PNG\r\n\x1A\n".unpack('C*') }
+        it { expect(image.type).to eq 'PNG' }
+        it { expect(image.dimensions).to eq [800, 600] }
+        it { expect(mean_colour_statistics(image)).to eq %w[0 0 255] }
       end
 
-      # Only test `emulateVisionDeficiency` if the Puppeteer supports it
-      if puppeteer_version_on_or_after? '3.2.0'
-        context 'when vision deficiency is set to `deuteranopia`' do
-          let(:url_or_html) { '<html><body style="background-color: red"></body></html>' }
-          let(:options) { { 'visionDeficiency' => 'deuteranopia' } }
+      context 'when vision deficiency is set to `deuteranopia`' do
+        let(:url_or_html) { '<html><body style="background-color: red"></body></html>' }
+        let(:options) { { 'visionDeficiency' => 'deuteranopia' } }
 
-          it { expect(convert.unpack('C*')).to start_with "\x89PNG\r\n\x1A\n".unpack('C*') }
-          it { expect(image.type).to eq 'PNG' }
-          it { expect(image.dimensions).to eq [800, 600] }
+        it { expect(convert.unpack('C*')).to start_with "\x89PNG\r\n\x1A\n".unpack('C*') }
+        it { expect(image.type).to eq 'PNG' }
+        it { expect(image.dimensions).to eq [800, 600] }
 
-          # For some reason, Chrome 98+ (v13.1.0+ of Puppeteer) handles deuteranopia vision deficiency differently
-          if puppeteer_version_on_or_after? '13.1.0'
-            it { expect(mean_colour_statistics(image)).to eq %w[163 144 0] }
-          else
-            it { expect(mean_colour_statistics(image)).to eq %w[94 71 0] }
-          end
-        end
+        it { expect(mean_colour_statistics(image)).to eq %w[163 144 0] }
       end
 
       context 'when specifying type of `png`' do

--- a/spec/grover_spec.rb
+++ b/spec/grover_spec.rb
@@ -6,6 +6,7 @@ describe Grover do
   let(:grover) { described_class.new(url_or_html, **options) }
   let(:url_or_html) { 'http://google.com' }
   let(:options) { {} }
+  let(:processor) { instance_double Grover::Processor }
 
   describe '.new' do
     subject(:new) { described_class.new('http://google.com') }
@@ -43,8 +44,6 @@ describe Grover do
 
   describe '#to_pdf' do
     subject(:to_pdf) { grover.to_pdf }
-
-    let(:processor) { instance_double Grover::Processor }
 
     before { allow(Grover::Processor).to receive(:new).with(Dir.pwd).and_return processor }
 
@@ -275,8 +274,6 @@ describe Grover do
   describe '#screenshot' do
     subject(:screenshot) { grover.screenshot }
 
-    let(:processor) { instance_double Grover::Processor }
-
     before { allow(Grover::Processor).to receive(:new).with(Dir.pwd).and_return processor }
 
     it 'calls to Grover::Processor' do
@@ -458,8 +455,6 @@ describe Grover do
   describe '#to_png' do
     subject(:to_png) { grover.to_png }
 
-    let(:processor) { instance_double Grover::Processor }
-
     before { allow(Grover::Processor).to receive(:new).with(Dir.pwd).and_return processor }
 
     it 'calls to Grover::Processor' do
@@ -489,8 +484,6 @@ describe Grover do
 
   describe '#to_jpeg' do
     subject(:to_jpeg) { grover.to_jpeg }
-
-    let(:processor) { instance_double Grover::Processor }
 
     before { allow(Grover::Processor).to receive(:new).with(Dir.pwd).and_return processor }
 
@@ -524,7 +517,6 @@ describe Grover do
   describe '#to_html' do
     subject(:to_html) { grover.to_html }
 
-    let(:processor) { instance_double Grover::Processor }
     let(:expected_html) { '<html><body>Some HTML</body></html>' }
 
     before { allow(Grover::Processor).to receive(:new).with(Dir.pwd).and_return processor }

--- a/spec/grover_spec.rb
+++ b/spec/grover_spec.rb
@@ -44,7 +44,7 @@ describe Grover do
   describe '#to_pdf' do
     subject(:to_pdf) { grover.to_pdf }
 
-    let(:processor) { instance_double 'Grover::Processor' }
+    let(:processor) { instance_double Grover::Processor }
 
     before { allow(Grover::Processor).to receive(:new).with(Dir.pwd).and_return processor }
 
@@ -62,10 +62,10 @@ describe Grover do
       it 'calls to Grover::Processor with the path specified' do
         allow(processor).to(
           receive(:convert).
-            with(:pdf, url_or_html, 'path' => '/foo/bar').
+            with(:pdf, url_or_html, { 'path' => '/foo/bar' }).
             and_return('some PDF content')
         )
-        expect(processor).to receive(:convert).with(:pdf, url_or_html, 'path' => '/foo/bar')
+        expect(processor).to receive(:convert).with(:pdf, url_or_html, { 'path' => '/foo/bar' })
         expect(to_pdf).to eq 'some PDF content'
       end
 
@@ -104,10 +104,10 @@ describe Grover do
       it 'builds options and passes them through to the processor' do
         allow(processor).to(
           receive(:convert).
-            with(:pdf, url_or_html, 'headerTemplate' => 'Some header').
+            with(:pdf, url_or_html, { 'headerTemplate' => 'Some header' }).
             and_return('some PDF content')
         )
-        expect(processor).to receive(:convert).with(:pdf, url_or_html, 'headerTemplate' => 'Some header')
+        expect(processor).to receive(:convert).with(:pdf, url_or_html, { 'headerTemplate' => 'Some header' })
         expect(to_pdf).to eq 'some PDF content'
       end
 
@@ -129,12 +129,12 @@ describe Grover do
         it 'builds options, overriding global options, and passes them through to the processor' do
           allow(processor).to(
             receive(:convert).
-              with(:pdf, url_or_html, 'headerTemplate' => 'instance header', 'footerTemplate' => 'instance footer').
+              with(:pdf, url_or_html, { 'headerTemplate' => 'instance header', 'footerTemplate' => 'instance footer' }).
               and_return('some PDF content')
           )
           expect(processor).to(
             receive(:convert).
-              with(:pdf, url_or_html, 'headerTemplate' => 'instance header', 'footerTemplate' => 'instance footer')
+              with(:pdf, url_or_html, { 'headerTemplate' => 'instance header', 'footerTemplate' => 'instance footer' })
           )
           expect(to_pdf).to eq 'some PDF content'
         end
@@ -171,12 +171,12 @@ describe Grover do
       it 'builds options and passes them through to the processor' do
         allow(processor).to(
           receive(:convert).
-            with(:pdf, url_or_html, 'footerTemplate' => "<div class='text'>Footer with \"quotes\" in it</div>").
+            with(:pdf, url_or_html, { 'footerTemplate' => "<div class='text'>Footer with \"quotes\" in it</div>" }).
             and_return('some PDF content')
         )
         expect(processor).to(
           receive(:convert).
-            with(:pdf, url_or_html, 'footerTemplate' => "<div class='text'>Footer with \"quotes\" in it</div>")
+            with(:pdf, url_or_html, { 'footerTemplate' => "<div class='text'>Footer with \"quotes\" in it</div>" })
         )
         expect(to_pdf).to eq 'some PDF content'
       end
@@ -196,10 +196,10 @@ describe Grover do
       it 'builds options and passes them through to the processor' do
         allow(processor).to(
           receive(:convert).
-            with(:pdf, url_or_html, 'launchArgs' => ['--disable-speech-api']).
+            with(:pdf, url_or_html, { 'launchArgs' => ['--disable-speech-api'] }).
             and_return('some PDF content')
         )
-        expect(processor).to receive(:convert).with(:pdf, url_or_html, 'launchArgs' => ['--disable-speech-api'])
+        expect(processor).to receive(:convert).with(:pdf, url_or_html, { 'launchArgs' => ['--disable-speech-api'] })
         expect(to_pdf).to eq 'some PDF content'
       end
     end
@@ -218,10 +218,10 @@ describe Grover do
       it 'builds options and passes them through to the processor' do
         allow(processor).to(
           receive(:convert).
-            with(:pdf, url_or_html, 'displayHeaderFooter' => false).
+            with(:pdf, url_or_html, { 'displayHeaderFooter' => false }).
             and_return('some PDF content')
         )
-        expect(processor).to receive(:convert).with(:pdf, url_or_html, 'displayHeaderFooter' => false)
+        expect(processor).to receive(:convert).with(:pdf, url_or_html, { 'displayHeaderFooter' => false })
         expect(to_pdf).to eq 'some PDF content'
       end
     end
@@ -243,12 +243,12 @@ describe Grover do
       it 'builds options and passes them through to the processor' do
         allow(processor).to(
           receive(:convert).
-            with(:pdf, url_or_html, 'viewport' => { 'height' => 100, 'width' => 200, 'deviceScaleFactor' => 2.5 }).
+            with(:pdf, url_or_html, { 'viewport' => { 'height' => 100, 'width' => 200, 'deviceScaleFactor' => 2.5 } }).
             and_return('some PDF content')
         )
         expect(processor).to(
           receive(:convert).
-            with(:pdf, url_or_html, 'viewport' => { 'height' => 100, 'width' => 200, 'deviceScaleFactor' => 2.5 })
+            with(:pdf, url_or_html, { 'viewport' => { 'height' => 100, 'width' => 200, 'deviceScaleFactor' => 2.5 } })
         )
         expect(to_pdf).to eq 'some PDF content'
       end
@@ -275,7 +275,7 @@ describe Grover do
   describe '#screenshot' do
     subject(:screenshot) { grover.screenshot }
 
-    let(:processor) { instance_double 'Grover::Processor' }
+    let(:processor) { instance_double Grover::Processor }
 
     before { allow(Grover::Processor).to receive(:new).with(Dir.pwd).and_return processor }
 
@@ -291,10 +291,10 @@ describe Grover do
       it 'calls to Grover::Processor with the path specified' do
         allow(processor).to(
           receive(:convert).
-            with(:screenshot, url_or_html, 'path' => '/foo/bar').
+            with(:screenshot, url_or_html, { 'path' => '/foo/bar' }).
             and_return('some image content')
         )
-        expect(processor).to receive(:convert).with(:screenshot, url_or_html, 'path' => '/foo/bar')
+        expect(processor).to receive(:convert).with(:screenshot, url_or_html, { 'path' => '/foo/bar' })
         expect(screenshot).to eq 'some image content'
       end
     end
@@ -308,10 +308,10 @@ describe Grover do
         it 'calls to Grover::Processor with the type specified' do
           allow(processor).to(
             receive(:convert).
-              with(:screenshot, url_or_html, 'type' => 'png').
+              with(:screenshot, url_or_html, { 'type' => 'png' }).
               and_return('some image content')
           )
-          expect(processor).to receive(:convert).with(:screenshot, url_or_html, 'type' => 'png')
+          expect(processor).to receive(:convert).with(:screenshot, url_or_html, { 'type' => 'png' })
           expect(screenshot).to eq 'some image content'
         end
       end
@@ -322,10 +322,10 @@ describe Grover do
         it 'calls to Grover::Processor with the type specified' do
           allow(processor).to(
             receive(:convert).
-              with(:screenshot, url_or_html, 'type' => 'jpeg').
+              with(:screenshot, url_or_html, { 'type' => 'jpeg' }).
               and_return('some image content')
           )
-          expect(processor).to receive(:convert).with(:screenshot, url_or_html, 'type' => 'jpeg')
+          expect(processor).to receive(:convert).with(:screenshot, url_or_html, { 'type' => 'jpeg' })
           expect(screenshot).to eq 'some image content'
         end
       end
@@ -361,10 +361,10 @@ describe Grover do
       it 'builds options and passes them through to the processor' do
         allow(processor).to(
           receive(:convert).
-            with(:screenshot, url_or_html, 'headerTemplate' => 'Some header').
+            with(:screenshot, url_or_html, { 'headerTemplate' => 'Some header' }).
             and_return('some image content')
         )
-        expect(processor).to receive(:convert).with(:screenshot, url_or_html, 'headerTemplate' => 'Some header')
+        expect(processor).to receive(:convert).with(:screenshot, url_or_html, { 'headerTemplate' => 'Some header' })
         expect(screenshot).to eq 'some image content'
       end
 
@@ -389,7 +389,7 @@ describe Grover do
               with(
                 :screenshot,
                 url_or_html,
-                'headerTemplate' => 'instance header', 'footerTemplate' => 'instance footer'
+                { 'headerTemplate' => 'instance header', 'footerTemplate' => 'instance footer' }
               ).
               and_return('some image content')
           )
@@ -398,7 +398,7 @@ describe Grover do
               with(
                 :screenshot,
                 url_or_html,
-                'headerTemplate' => 'instance header', 'footerTemplate' => 'instance footer'
+                { 'headerTemplate' => 'instance header', 'footerTemplate' => 'instance footer' }
               )
           )
           expect(screenshot).to eq 'some image content'
@@ -438,7 +438,7 @@ describe Grover do
             with(
               :screenshot,
               url_or_html,
-              'viewport' => { 'height' => 100, 'width' => 200, 'deviceScaleFactor' => 2.5 }
+              { 'viewport' => { 'height' => 100, 'width' => 200, 'deviceScaleFactor' => 2.5 } }
             ).
             and_return('some image content')
         )
@@ -447,7 +447,7 @@ describe Grover do
             with(
               :screenshot,
               url_or_html,
-              'viewport' => { 'height' => 100, 'width' => 200, 'deviceScaleFactor' => 2.5 }
+              { 'viewport' => { 'height' => 100, 'width' => 200, 'deviceScaleFactor' => 2.5 } }
             )
         )
         expect(screenshot).to eq 'some image content'
@@ -458,17 +458,17 @@ describe Grover do
   describe '#to_png' do
     subject(:to_png) { grover.to_png }
 
-    let(:processor) { instance_double 'Grover::Processor' }
+    let(:processor) { instance_double Grover::Processor }
 
     before { allow(Grover::Processor).to receive(:new).with(Dir.pwd).and_return processor }
 
     it 'calls to Grover::Processor' do
       allow(processor).to(
         receive(:convert).
-          with(:screenshot, url_or_html, 'type' => 'png').
+          with(:screenshot, url_or_html, { 'type' => 'png' }).
           and_return('some PNG content')
       )
-      expect(processor).to receive(:convert).with(:screenshot, url_or_html, 'type' => 'png')
+      expect(processor).to receive(:convert).with(:screenshot, url_or_html, { 'type' => 'png' })
       expect(to_png).to eq 'some PNG content'
     end
 
@@ -478,10 +478,10 @@ describe Grover do
       it 'calls to Grover::Processor with the path specified' do
         allow(processor).to(
           receive(:convert).
-            with(:screenshot, url_or_html, 'path' => '/foo/bar', 'type' => 'png').
+            with(:screenshot, url_or_html, { 'path' => '/foo/bar', 'type' => 'png' }).
             and_return('some PNG content')
         )
-        expect(processor).to receive(:convert).with(:screenshot, url_or_html, 'path' => '/foo/bar', 'type' => 'png')
+        expect(processor).to receive(:convert).with(:screenshot, url_or_html, { 'path' => '/foo/bar', 'type' => 'png' })
         expect(to_png).to eq 'some PNG content'
       end
     end
@@ -490,17 +490,17 @@ describe Grover do
   describe '#to_jpeg' do
     subject(:to_jpeg) { grover.to_jpeg }
 
-    let(:processor) { instance_double 'Grover::Processor' }
+    let(:processor) { instance_double Grover::Processor }
 
     before { allow(Grover::Processor).to receive(:new).with(Dir.pwd).and_return processor }
 
     it 'calls to Grover::Processor' do
       allow(processor).to(
         receive(:convert).
-          with(:screenshot, url_or_html, 'type' => 'jpeg').
+          with(:screenshot, url_or_html, { 'type' => 'jpeg' }).
           and_return('some JPG content')
       )
-      expect(processor).to receive(:convert).with(:screenshot, url_or_html, 'type' => 'jpeg')
+      expect(processor).to receive(:convert).with(:screenshot, url_or_html, { 'type' => 'jpeg' })
 
       expect(to_jpeg).to eq 'some JPG content'
     end
@@ -511,10 +511,11 @@ describe Grover do
       it 'calls to Grover::Processor with the path specified' do
         allow(processor).to(
           receive(:convert).
-            with(:screenshot, url_or_html, 'path' => '/foo/bar', 'type' => 'jpeg').
+            with(:screenshot, url_or_html, { 'path' => '/foo/bar', 'type' => 'jpeg' }).
             and_return('some JPG content')
         )
-        expect(processor).to receive(:convert).with(:screenshot, url_or_html, 'path' => '/foo/bar', 'type' => 'jpeg')
+        expect(processor).to receive(:convert).with(:screenshot, url_or_html,
+                                                    { 'path' => '/foo/bar', 'type' => 'jpeg' })
         expect(to_jpeg).to eq 'some JPG content'
       end
     end
@@ -523,7 +524,7 @@ describe Grover do
   describe '#to_html' do
     subject(:to_html) { grover.to_html }
 
-    let(:processor) { instance_double 'Grover::Processor' }
+    let(:processor) { instance_double Grover::Processor }
     let(:expected_html) { '<html><body>Some HTML</body></html>' }
 
     before { allow(Grover::Processor).to receive(:new).with(Dir.pwd).and_return processor }
@@ -610,36 +611,36 @@ describe Grover do
   describe '#show_front_cover?' do
     subject(:show_front_cover?) { grover.show_front_cover? }
 
-    it { is_expected.to eq false }
+    it { is_expected.to be false }
 
     context 'when option specified' do
       let(:options) { { front_cover_path: '/baz' } }
 
-      it { is_expected.to eq true }
+      it { is_expected.to be true }
     end
 
     context 'when the option isnt a path' do
       let(:options) { { front_cover_path: 'http://example.com/baz' } }
 
-      it { is_expected.to eq false }
+      it { is_expected.to be false }
     end
   end
 
   describe '#show_back_cover?' do
     subject(:show_back_cover?) { grover.show_back_cover? }
 
-    it { is_expected.to eq false }
+    it { is_expected.to be false }
 
     context 'when option specified' do
       let(:options) { { back_cover_path: '/baz' } }
 
-      it { is_expected.to eq true }
+      it { is_expected.to be true }
     end
 
     context 'when the option isnt a path' do
       let(:options) { { back_cover_path: 'http://example.com/baz' } }
 
-      it { is_expected.to eq false }
+      it { is_expected.to be false }
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,5 +20,6 @@ end
 MiniMagick.validate_on_create = false
 
 def puppeteer_version_on_or_after?(version)
-  ENV['PUPPETEER_VERSION'].to_s == '' || Gem::Version.new(ENV['PUPPETEER_VERSION']) >= Gem::Version.new(version)
+  puppeteer_version = ENV.fetch('PUPPETEER_VERSION', '')
+  puppeteer_version.empty? || Gem::Version.new(puppeteer_version) >= Gem::Version.new(version)
 end


### PR DESCRIPTION
**Changes:**

- Added compatibility for ruby 3.2.0
- Tested with newer versions of puppeteer
- Miscellaneous (rubocop, manual) fixes
- Github actions update

**Questions:**

- Do we need to test puppeteer as far as v1 given still suported nodejs versions?
  - If not can we clear up tests that depends on puppeteer version (`puppeteer_version_on_or_after?`)? 
- Some [tests](https://github.com/Studiosity/grover/pull/170/files#diff-beedb588836752a1b300209c575d884951d3cca658813e67c9d1dad7164babf1L367) depends on [external resources](https://cookie-renderer.herokuapp.com/) which are now failing - probably because heroxu axed free dynos. Any sugestions if/how to replace that?