### PR TITLE
Implement remote browser option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      remote-chrome:
+        image: browserless/chrome:1.57-puppeteer-19.2.2
+        ports:
+          - 3000:3000
     strategy:
       fail-fast: false
       matrix:
@@ -61,6 +66,11 @@ jobs:
 
       - name: Run tests
         run: bundle exec rspec
+        env:
+          PUPPETEER_VERSION: ${{ matrix.puppeteer-version }}
+
+      - name: Run tests with remote browser
+        run: bundle exec rspec --tag remote-browser
         env:
           PUPPETEER_VERSION: ${{ matrix.puppeteer-version }}
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,21 @@ only really makes sense if you're calling Grover directly (and not via middlewar
 Grover.new('<some URI with basic authentication', username: 'the username', password: 'super secret').to_pdf
 ```
 
+#### Remote Chromium
+
+By default, Grover launches a local Chromium instance. You can connect to a remote/external
+Chromium with the `browser_ws_endpoint` options.
+
+For example, to connect to a chrome instance started with docker using `docker run -p 3000:3000 browserless/chrome:latest`:
+
+```ruby
+options = {"browser_ws_endpoint": "ws://localhost:3000/"}
+grover = Grover.new("https://mysite.com/path/to/thing", options)
+File.open("grover.png", "wb") { |f| f << grover.to_png }
+```
+
+You can also pass launch flags like this: `ws://localhost:3000/?--disable-speech-api`
+
 #### Adding cookies
 To set request cookies when requesting a URL, pass an array of hashes as such
 _N.B._ Only the `name` and `value` properties are required.

--- a/README.md
+++ b/README.md
@@ -490,6 +490,12 @@ $ rubocop
 both succeed
 
 
+To run tests tagged with `remote_browser`, you need to start a browser in a container:
+`docker run -p 3000:3000 browserless/chrome:latest`
+and run:
+`rspec --tag remote_browser`
+
+
 ## Special mention
 Thanks are given to the great work done in the [PDFKit project](https://github.com/pdfkit/pdfkit).
 The middleware and HTML preprocessing components were used heavily in the implementation of Grover.

--- a/lib/grover/js/processor.cjs
+++ b/lib/grover/js/processor.cjs
@@ -17,13 +17,13 @@ const path = require('path');
 const _processPage = (async (convertAction, urlOrHtml, options) => {
   let browser, errors = [], tmpDir;
 
-  // Configure puppeteer debugging options
-  const debug = options.debug; delete options.debug;
-  const remoteConnect = typeof options.browserWsEndpoint === "string";
   try {
-    if (remoteConnect) {
+    // Configure puppeteer debugging options
+    const debug = options.debug; delete options.debug;
+    const browserWsEndpoint = options.browserWsEndpoint; delete options.browserWsEndpoint;
+    if (typeof browserWsEndpoint === "string") {
       const connectParams = {
-        browserWSEndpoint: options.browserWsEndpoint,
+        browserWSEndpoint: browserWsEndpoint,
       };
 
       browser = await puppeteer.connect(connectParams);

--- a/lib/grover/js/processor.cjs
+++ b/lib/grover/js/processor.cjs
@@ -16,35 +16,46 @@ const path = require('path');
 
 const _processPage = (async (convertAction, urlOrHtml, options) => {
   let browser, errors = [], tmpDir;
+
+  // Configure puppeteer debugging options
+  const debug = options.debug; delete options.debug;
+  const remoteConnect = typeof options.browserWsEndpoint === "string";
   try {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'grover-'));
+    if (remoteConnect) {
+      const connectParams = {
+        browserWSEndpoint: options.browserWsEndpoint,
+      };
 
-    const launchParams = {
-      args: process.env.GROVER_NO_SANDBOX === 'true' ? ['--no-sandbox', '--disable-setuid-sandbox'] : [],
-      userDataDir: tmpDir
-    };
+      browser = await puppeteer.connect(connectParams);
+    } else {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'grover-'));
 
-    // Configure puppeteer debugging options
-    const debug = options.debug; delete options.debug;
-    if (typeof debug === 'object' && !!debug) {
-      if (debug.headless !== undefined) { launchParams.headless = debug.headless; }
-      if (debug.devtools !== undefined) { launchParams.devtools = debug.devtools; }
+      const launchParams = {
+        args: process.env.GROVER_NO_SANDBOX === 'true' ? ['--no-sandbox', '--disable-setuid-sandbox'] : [],
+        userDataDir: tmpDir
+      };
+  
+      if (typeof debug === 'object' && !!debug) {
+        if (debug.headless !== undefined) { launchParams.headless = debug.headless; }
+        if (debug.devtools !== undefined) { launchParams.devtools = debug.devtools; }
+      }
+  
+      // Configure additional launch arguments
+      const args = options.launchArgs; delete options.launchArgs;
+      if (Array.isArray(args)) {
+        launchParams.args = launchParams.args.concat(args);
+      }
+  
+      // Set executable path if given
+      const executablePath = options.executablePath; delete options.executablePath;
+      if (executablePath) {
+        launchParams.executablePath = executablePath;
+      }
+  
+      // Launch the browser and create a page
+      browser = await puppeteer.launch(launchParams);
     }
 
-    // Configure additional launch arguments
-    const args = options.launchArgs; delete options.launchArgs;
-    if (Array.isArray(args)) {
-      launchParams.args = launchParams.args.concat(args);
-    }
-
-    // Set executable path if given
-    const executablePath = options.executablePath; delete options.executablePath;
-    if (executablePath) {
-      launchParams.executablePath = executablePath;
-    }
-
-    // Launch the browser and create a page
-    browser = await puppeteer.launch(launchParams);
     const page = await browser.newPage();
 
     // Basic auth

--- a/spec/grover/processor_spec.rb
+++ b/spec/grover/processor_spec.rb
@@ -404,6 +404,32 @@ describe Grover::Processor do
         end
       end
 
+      context 'when passing through launch params to remote browser', remote_browser: true do
+        let(:options) { { 'browserWsEndpoint' => browser_ws_endpoint } }
+        let(:browser_ws_endpoint) { 'ws://localhost:3000/' }
+        let(:url_or_html) do
+          <<-HTML
+            <html>
+              <body>
+                Speech recognition is <span id="test" />
+                <script type="text/javascript">
+                  var speechSupported = "webkitSpeechRecognition" in window;
+                  document.getElementById("test").innerHTML = speechSupported ? "supported" : "not supported"
+                </script>
+              </body>
+            </html>
+          HTML
+        end
+
+        it { expect(pdf_text_content).to eq 'Speech recognition is supported' }
+
+        context 'when WS endpoint param specifies disabling the speech API' do
+          let(:browser_ws_endpoint) { 'ws://localhost:3000/?--disable-speech-api' }
+
+          it { expect(pdf_text_content).to eq 'Speech recognition is not supported' }
+        end
+      end
+
       context 'when HTML includes screen only content' do
         let(:url_or_html) do
           <<-HTML

--- a/spec/grover/processor_spec.rb
+++ b/spec/grover/processor_spec.rb
@@ -875,6 +875,16 @@ describe Grover::Processor do
         it { expect(mean_colour_statistics(image)).to eq %w[0 0 255] }
       end
 
+      context 'when using remote browser option with HTML', remote_browser: true do
+        let(:options) { { browserWsEndpoint: 'ws://localhost:3000' } }
+        let(:url_or_html) { '<html><body style="background-color: blue"></body></html>' }
+
+        it { expect(convert.unpack('C*')).to start_with "\x89PNG\r\n\x1A\n".unpack('C*') }
+        it { expect(image.type).to eq 'PNG' }
+        it { expect(image.dimensions).to eq [800, 600] }
+        it { expect(mean_colour_statistics(image)).to eq %w[0 0 255] }
+      end
+
       context 'when HTML requests external assets' do
         let(:url_or_html) do
           <<~HTML

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ require 'mini_magick'
 
 RSpec.configure do |config|
   config.order = 'random'
+  config.filter_run_excluding remote_browser: true
 
   include Rack::Test::Methods
 end


### PR DESCRIPTION
Idea taken from: https://github.com/Studiosity/grover/pull/115 from @drnic

---

Can be used with

```ruby
Grover.new(..., browser_ws_endpoint: "ws://localhost:3333")
```

and e.g. a `docker-compose.yaml` file like:
```yaml
version: "3.7"
services:
  chrome:
    image: browserless/chrome:1.57-puppeteer-19.2.2
    ports:
      - 3333:3000
```

Hopefully this PR is much easier to review and merge than the original one where I took the idea from.

We have been using this in a production system for a couple of months and haven't had any issues with this setup.

---

I can include an update to the docs with this PR as well, but I wasn't sure where exactly I should put this.