### PR TITLE
Clean up temporary user data directory

### DIFF
--- a/lib/grover/js/processor.cjs
+++ b/lib/grover/js/processor.cjs
@@ -10,11 +10,18 @@ try {
 }
 process.stdout.write("[\"ok\"]\n");
 
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
 const _processPage = (async (convertAction, urlOrHtml, options) => {
-  let browser, errors = [];
+  let browser, errors = [], tmpDir;
   try {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'grover-'));
+
     const launchParams = {
-      args: process.env.GROVER_NO_SANDBOX === 'true' ? ['--no-sandbox', '--disable-setuid-sandbox'] : []
+      args: process.env.GROVER_NO_SANDBOX === 'true' ? ['--no-sandbox', '--disable-setuid-sandbox'] : [],
+      userDataDir: tmpDir
     };
 
     // Configure puppeteer debugging options
@@ -245,6 +252,10 @@ const _processPage = (async (convertAction, urlOrHtml, options) => {
     if (browser) {
       await browser.close();
     }
+
+    try {
+      if (tmpDir) fs.rmSync(tmpDir, { recursive: true });
+    } catch { }
   }
 });
 


### PR DESCRIPTION
If not specified, the temporary user data directory is not cleaned up automatically. This can eventually result in the filesystem getting filled with puppeteer chrome profile files.