### PR TITLE
[readme] Clarify execute_script option

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ if the initial content request or any subsequent asset request returns a bad res
 
 The Chrome/Chromium executable path can be overridden with the `executable_path` option.
 
-Javascript can be executed on the page (after render and before conversion to PDF/image)
-with the `execute_script` option.
+Supplementary JavaScript can be executed on the page (after render and before conversion to PDF/image)
+by passing it to the `execute_script` option.
 
 #### Basic authentication
 For requesting a page with basic authentication, `username` and `password` options can be provided. Note that this

--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ The Chrome/Chromium executable path can be overridden with the `executable_path`
 Supplementary JavaScript can be executed on the page (after render and before conversion to PDF/image)
 by passing it to the `execute_script` option.
 
+```javascript
+Grover.new(<some url>, { execute_script: 'document.getElementsByTagName("footer")[0].innerText = "Hey"' }).to_pdf
+```
+
 #### Basic authentication
 For requesting a page with basic authentication, `username` and `password` options can be provided. Note that this
 only really makes sense if you're calling Grover directly (and not via middleware).


### PR DESCRIPTION
To protect my reputation, I will not mention how long it took before I realized `execute_script` is not a boolean option that causes JavaScript to run. Hopefully this PR clarifies the option a bit. Happy to improve the PR if my update is not completely accurate as to what `execute_script` will accept.

Thanks for your work on Grover! This is a huge improvement over our previous tool.

---

If you're curious, passing `true` to `execute_script` produces an error which can really lead you down a rabbit hole if you mistakenly assume it's a boolean:

```
/Users/david/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/gems/grover-1.1.4/lib/grover/processor.rb:92:in `call_js_method': Protocol error (Runtime.callFunctionOn): Given expression does not evaluate to a function (Grover::JavaScript::ProtocolError)
```

To make matters worse, if you add debugging statements to output the function name it's trying to run, the output is `screenshot`, not `true`. In retrospect, I understand why this is now, and the problem is obvious. My error was probably built on a number of my own misunderstandings, and on all the context switching I've had to do lately. Hopefully this prevents others from making the same mistake I did!