### PR TITLE
Fix Rubocop lint

### DIFF
--- a/lib/grover/options_builder.rb
+++ b/lib/grover/options_builder.rb
@@ -9,6 +9,7 @@ class Grover
   #
   class OptionsBuilder < Hash
     def initialize(options, url)
+      super()
       @url = url
       combined = grover_configuration
       Utils.deep_merge! combined, Utils.deep_stringify_keys(options)


### PR DESCRIPTION
Fixed the newly failing lint that was blocking running tests.

Note that tests are still failing.  It looks like an issue with `https://cookierenderer-production.up.railway.app/`