### PR TITLE
Perform the error handling for `raise_request_on_failer` before waiting for selectors / functions

### DIFF
--- a/lib/grover/js/processor.cjs
+++ b/lib/grover/js/processor.cjs
@@ -17,6 +17,28 @@ const path = require('path');
 const _processPage = (async (convertAction, urlOrHtml, options) => {
   let browser, errors = [], tmpDir;
 
+  const handleErrors = () => {
+
+    function RequestFailedError(errors) {
+      this.name = "RequestFailedError";
+      this.message = errors.map(e => {
+        if (e.failure()) {
+          return e.failure().errorText + " at " + e.url();
+        } else if (e.response() && e.response().status()) {
+          return e.response().status() + " " + e.url();
+        } else {
+          return "UnknownError " + e.url()
+        }
+      }).join("\n");
+    }
+
+    RequestFailedError.prototype = Error.prototype;
+
+    if (errors.length > 0) {
+      throw new RequestFailedError(errors);
+    }
+  }
+
   try {
     // Configure puppeteer debugging options
     const debug = options.debug; delete options.debug;
@@ -34,24 +56,24 @@ const _processPage = (async (convertAction, urlOrHtml, options) => {
         args: process.env.GROVER_NO_SANDBOX === 'true' ? ['--no-sandbox', '--disable-setuid-sandbox'] : [],
         userDataDir: tmpDir
       };
-  
+
       if (typeof debug === 'object' && !!debug) {
         if (debug.headless !== undefined) { launchParams.headless = debug.headless; }
         if (debug.devtools !== undefined) { launchParams.devtools = debug.devtools; }
       }
-  
+
       // Configure additional launch arguments
       const args = options.launchArgs; delete options.launchArgs;
       if (Array.isArray(args)) {
         launchParams.args = launchParams.args.concat(args);
       }
-  
+
       // Set executable path if given
       const executablePath = options.executablePath; delete options.executablePath;
       if (executablePath) {
         launchParams.executablePath = executablePath;
       }
-  
+
       // Launch the browser and create a page
       browser = await puppeteer.launch(launchParams);
     }
@@ -172,6 +194,8 @@ const _processPage = (async (convertAction, urlOrHtml, options) => {
       await page.goto(displayUrl || 'http://example.com', requestOptions);
     }
 
+    handleErrors();
+
     // add styles (if provided)
     const styleTagOptions = options.styleTagOptions; delete options.styleTagOptions;
     if (Array.isArray(styleTagOptions)) {
@@ -230,23 +254,6 @@ const _processPage = (async (convertAction, urlOrHtml, options) => {
     const hoverSelector = options.hover; delete options.hover;
     if (hoverSelector !== undefined) {
       await page.hover(hoverSelector);
-    }
-
-    if (errors.length > 0) {
-      function RequestFailedError(errors) {
-        this.name = "RequestFailedError";
-        this.message = errors.map(e => {
-          if (e.failure()) {
-            return e.failure().errorText + " at " + e.url();
-          } else if (e.response() && e.response().status()) {
-            return e.response().status() + " " + e.url();
-          } else {
-            return "UnknownError " + e.url()
-          }
-        }).join("\n");
-      }
-      RequestFailedError.prototype = Error.prototype;
-      throw new RequestFailedError(errors);
     }
 
     // Setup conversion timeout


### PR DESCRIPTION
According to the docs:

> The raise_on_request_failure option, when enabled, will raise a Grover::JavaScript::RequestFailedError if the initial content request or any subsequent asset request returns a bad response or times out.

However, as it is, the error will only be raised *after* the `wait_for_selector` or `wait_for_function` are performed.

This means that, for example, if grover hits a 401 (Unauthorized) response when visiting a URL, it **will not** raise immediately; instead, it will time out because the selector wasn't found.

This pull request extracts the error handling to a separate function, and invokes it after the page navigation, so that if `raise_on_request_failure` is `true`, an error will be raised without having to wait for a selector/function that will inevitably never happen. 