### PR TITLE
Attempt to run on Ruby 3.3.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.2']
+        ruby-version: ['3.3']
         node-version: ['14']
         puppeteer-version: [
           '14.4.1',
@@ -41,6 +41,9 @@ jobs:
             node-version: '16'
             puppeteer-version: '19.5.2'
           - ruby-version: '3.2'
+            node-version: '18'
+            puppeteer-version: '19.5.2'
+          - ruby-version: '3.3'
             node-version: '18'
             puppeteer-version: '19.5.2'
 

--- a/grover.gemspec
+++ b/grover.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   SUMMARY
   spec.homepage    = 'https://github.com/Studiosity/grover'
   spec.license     = 'MIT'
-  spec.required_ruby_version = ['>= 2.7.0', '< 3.3.0']
+  spec.required_ruby_version = ['>= 2.7.0', '< 3.4.0']
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.


### PR DESCRIPTION
I created this branch to make the gem compatible with Ruby 3.3.0.

I couldn't get all the specs to pass locally but that's probably a problem with my local environment because I can't get them to pass with an older Ruby version either. I opened this PR in the hopes that CI would run against this branch.

Related to https://github.com/Studiosity/grover/issues/212.