### PR TITLE
Enable passing environment variables to the node process

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,16 @@ respond_to do |format|
 end
 ```
 
+#### Setting custom environment variable for node
+The `node_env_vars` configuration option enables you to set custom environment variables for the spawned node process. For example you might need to disable jemalloc in some environments (https://github.com/Studiosity/grover/issues/80).
+
+```ruby
+# config/initializers/grover.rb
+Grover.configure do |config|
+  config.node_env_vars = { "LD_PRELOAD" => "" }
+end
+```
+
 ## Middleware
 Grover comes with a middleware that allows users to get a PDF, PNG or JPEG view of
 any page on your site by appending .pdf, .png or .jpeg/.jpg to the URL.

--- a/lib/grover/configuration.rb
+++ b/lib/grover/configuration.rb
@@ -7,7 +7,7 @@ class Grover
   class Configuration
     attr_accessor :options, :meta_tag_prefix, :ignore_path, :ignore_request,
                   :root_url, :use_pdf_middleware, :use_png_middleware,
-                  :use_jpeg_middleware
+                  :use_jpeg_middleware, :node_env_vars
 
     def initialize
       @options = {}
@@ -18,6 +18,7 @@ class Grover
       @use_pdf_middleware = true
       @use_png_middleware = false
       @use_jpeg_middleware = false
+      @node_env_vars = {}
     end
   end
 end

--- a/lib/grover/processor.rb
+++ b/lib/grover/processor.rb
@@ -32,6 +32,7 @@ class Grover
 
     def spawn_process
       @stdin, @stdout, @stderr, @wait_thr = Open3.popen3(
+        Grover.configuration.node_env_vars,
         'node',
         File.expand_path(File.join(__dir__, 'js/processor.cjs')),
         chdir: app_root

--- a/spec/grover/processor_spec.rb
+++ b/spec/grover/processor_spec.rb
@@ -106,6 +106,16 @@ describe Grover::Processor do
         end
       end
 
+      context 'when passing environment variables to the Node process through configuration' do
+        before { allow(Grover.configuration).to receive(:node_env_vars).and_return 'FOO' => 'bar'}
+
+        it 'passes the environment variables to the Node process' do
+          expect(Open3).to receive(:popen3).with({ 'FOO' => 'bar' }, any_args).and_call_original
+
+          convert
+        end
+      end
+
       if puppeteer_version_on_or_after? '18.0.0'
         context 'when only the puppeteer-core package is installed', :remote_browser do
           before { FileUtils.move 'node_modules/puppeteer', 'node_modules/puppeteer_temp' }
@@ -129,7 +139,8 @@ describe Grover::Processor do
         before do
           allow(Open3).to(
             receive(:popen3).
-              with('node', File.expand_path(File.join(__dir__, '../../lib/grover/js/processor.cjs')), chdir: Dir.pwd).
+              with({}, 'node', File.expand_path(File.join(__dir__,
+                                                          '../../lib/grover/js/processor.cjs')), chdir: Dir.pwd).
               and_return([stdin, stdout, stderr, wait_thr])
           )
 

--- a/spec/grover/processor_spec.rb
+++ b/spec/grover/processor_spec.rb
@@ -107,7 +107,7 @@ describe Grover::Processor do
       end
 
       context 'when passing environment variables to the Node process through configuration' do
-        before { allow(Grover.configuration).to receive(:node_env_vars).and_return 'FOO' => 'bar'}
+        before { allow(Grover.configuration).to receive(:node_env_vars).and_return 'FOO' => 'bar' }
 
         it 'passes the environment variables to the Node process' do
           expect(Open3).to receive(:popen3).with({ 'FOO' => 'bar' }, any_args).and_call_original

--- a/spec/grover/processor_spec.rb
+++ b/spec/grover/processor_spec.rb
@@ -714,7 +714,7 @@ describe Grover::Processor do
               <html>
                 <head><link rel='icon' href='data:;base64,iVBORw0KGgo='></head>
                 <body>
-                  <img src="https://placekitten.com/200/200" />
+                  <img src="http://localhost:4567/cat.png" />
                 </body>
               </html>
             HTML


### PR DESCRIPTION
We noticed that Chrome does not behave well with jemalloc enabled, and we prefer to use that in general. 

Instead of disabling jemalloc in the whole environment, we opted to just disable it for the node process used. Based on quick search, others have had the same issue as well (https://github.com/Studiosity/grover/issues/80)

We disabled it by passing a new environment variable for the node process like this