### PR TITLE
fix: introduce ignoreDefaultArgs into launchParams

### DIFF
--- a/lib/grover/js/processor.cjs
+++ b/lib/grover/js/processor.cjs
@@ -74,6 +74,11 @@ const _processPage = (async (convertAction, uriOrHtml, options) => {
         launchParams.executablePath = executablePath;
       }
 
+      // ignoreDefaultArgs
+      if (options.ignoreDefaultArgs) {
+        launchParams.ignoreDefaultArgs = options.ignoreDefaultArgs;
+      }
+
       // Launch the browser and create a page
       browser = await puppeteer.launch(launchParams);
     }

--- a/spec/grover/processor_spec.rb
+++ b/spec/grover/processor_spec.rb
@@ -428,6 +428,27 @@ describe Grover::Processor do
           end
         end
 
+        context 'when options include ignoreDefaultArgs' do
+          context 'when --disable-component-update is provided' do
+            let(:options) { { 'ignoreDefaultArgs' => ['--disable-component-update'] } }
+            let(:url_or_html) do
+              <<-HTML
+            <html>
+              <body lang="de" style="font-family: 'DejaVu Sans'; font-size: 10px; width: 100px; hyphens: auto;">
+              <p>
+                Testgetriebene Entwicklung ist eine Methode.
+              </p>
+              </body>
+            </html>
+              HTML
+            end
+
+            it do
+              expect(pdf_text_content).to eq 'Testgetriebene Ent‐ wicklung ist eine Methode.'
+            end
+          end
+        end
+
         context 'when requesting a URI requiring basic authentication' do
           let(:url_or_html) { 'http://localhost:4567/auth' }
 


### PR DESCRIPTION
I encountered an issue when using German hyphens on Linux.

<img width="470" alt="Snímek obrazovky 2024-07-11 v 13 34 02" src="https://github.com/Studiosity/grover/assets/340649/24553623-ff01-4a1f-9d68-0e8390812143">

The following images were generated with identical code on different environments.
The left side is Linux, and the right side is MacOS.
Here is a bug report on the Chromium website: https://issues.chromium.org/issues/40933841
There is a workaround for Puppeteer:
```
puppeteer.launch({
  ignoreDefaultArgs: ['--disable-component-update'],
})
```

Unfortunately,`ignoreDefaultArgs` are not passed via Grover. 
This PR fixes it.