### PR TITLE
Add support for Puppeteer v23.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,32 +20,32 @@ jobs:
         ruby-version: ['3.3']
         node-version: ['18']
         puppeteer-version: [
-          '17.1.3',
           '18.2.1',
           '19.11.1',
           '20.9.0',
           '21.9.0',
-          '22.12.0'
+          '22.15.0',
+          '23.2.1',
         ]
         include:
           - ruby-version: '2.7'
             node-version: '18'
-            puppeteer-version: '22.12.0'
+            puppeteer-version: '23.2.1'
           - ruby-version: '3.0'
             node-version: '18'
-            puppeteer-version: '22.12.0'
+            puppeteer-version: '23.2.1'
           - ruby-version: '3.1'
             node-version: '18'
-            puppeteer-version: '22.12.0'
+            puppeteer-version: '23.2.1'
           - ruby-version: '3.2'
             node-version: '18'
-            puppeteer-version: '22.12.0'
+            puppeteer-version: '23.2.1'
           - ruby-version: '3.3'
             node-version: '20'
-            puppeteer-version: '22.12.0'
+            puppeteer-version: '23.2.1'
           - ruby-version: '3.3'
             node-version: '22'
-            puppeteer-version: '22.12.0'
+            puppeteer-version: '23.2.1'
 
     steps:
       - uses: actions/checkout@v3

--- a/lib/grover/js/processor.cjs
+++ b/lib/grover/js/processor.cjs
@@ -282,7 +282,7 @@ const _processPage = (async (convertAction, uriOrHtml, options) => {
 
     // If we're running puppeteer in headless mode, return the converted PDF
     if (debug === undefined || (typeof debug === 'object' && (debug.headless === undefined || debug.headless))) {
-      return await page[convertAction](options);
+      return Buffer.from(await page[convertAction](options));
     }
   } finally {
     if (browser) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grover",
-  "version": "1.1.7",
+  "version": "1.1.9",
   "description": "A Ruby gem to transform HTML into PDFs using Google Puppeteer/Chromium",
   "repository": {
     "type": "git",
@@ -18,6 +18,6 @@
   },
   "homepage": "https://github.com/Studiosity/grover#readme",
   "devDependencies": {
-    "puppeteer": "^22.12.0"
+    "puppeteer": "^23.2.1"
   }
 }


### PR DESCRIPTION
Puppeteer 23.x has switch from returning a `Buffer` to returning `Uint8Array` which has broken the result parsing in Grover. This wraps the convert action with `Buffer.from` (supports both `Buffer` and `Uint8Array`) to return a `Buffer` in a consistent way.