### PR TITLE
Attempt to use pnp strategy to find puppeteer

### DIFF
--- a/lib/grover/js/processor.cjs
+++ b/lib/grover/js/processor.cjs
@@ -1,4 +1,42 @@
-// Setup imports
+const fs = require('fs')
+const path = require('path')
+
+function findPnpFile(startDir) {
+  let currentDir = startDir;
+  while (currentDir !== path.parse(currentDir).root) {
+      const pnpPath = path.join(currentDir, '.pnp.cjs');
+      if (fs.existsSync(pnpPath)) {
+          return pnpPath;
+      }
+      currentDir = path.dirname(currentDir);
+  }
+  return null;
+}
+
+function checkPuppeteerInstalledWithPnp() {
+  const pnpPath = findPnpFile(process.cwd());
+
+  if (!pnpPath) {
+    throw('Error: .pnp.cjs file not found.');
+  }
+
+  try {
+    require(pnpPath).setup();
+    try {
+      require('puppeteer');
+    } catch (error) {
+      try {
+        require('puppeteer-core');
+      } catch (error) {
+        throw (error);
+      }
+    }
+    return true;
+  } catch (error) {
+    throw (error);
+  }
+}
+
 try {
   const Module = require('module');
 
@@ -10,8 +48,13 @@ try {
       // try resolve `puppeteer-core` library instead
       var puppeteer = require(require.resolve('puppeteer-core', { paths: Module._nodeModulePaths(process.cwd()) }));
     } catch (coreError) {
-      // raise the original puppeteer load issue so we don't send people don't the wrong rabbit hole by default.
-      throw puppeteerError;
+      try {
+        // attempt to use pnp strategy (yarn 3+)
+        checkPuppeteerInstalledWithPnp();
+      } catch (pnpError) {
+        // raise the original puppeteer load issue so we don't send people don't the wrong rabbit hole by default.
+        throw puppeteerError;
+      }
     }
   }
 } catch (e) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grover",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "A Ruby gem to transform HTML into PDFs using Google Puppeteer/Chromium",
   "repository": {
     "type": "git",


### PR DESCRIPTION
If using Yarn 3+, the default strategy is [Yarn Plug'n'Play](https://yarnpkg.com/features/pnp).  The Grover gem errors on initialization because it can't find the puppeteer(-core) library, given there is no `node_modules` folder... This modification attempts to find `puppeteer` via `.pnp.cjs`