### PR TITLE
Optional combine_pdf + support yarn pnp

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'childprocess', '~> 5.0'
+gem 'combine_pdf', '~> 1.0'
 gem 'mini_magick', '~> 4.12'
 gem 'pdf-reader', '~> 2.11'
 gem 'puma', '~> 6.4'

--- a/README.md
+++ b/README.md
@@ -300,6 +300,16 @@ Grover.configure do |config|
 end
 ```
 
+#### Yarn pnp strategy
+
+If you ar using yarn pnp strategy, you can override how to run js runtime for grover:
+
+```ruby
+Grover.configure do |config|
+  config.js_runtime_bin = ['yarn', 'node']
+end
+```
+
 ## Middleware
 Grover comes with a middleware that allows users to get a PDF, PNG or JPEG view of
 any page on your site by appending .pdf, .png or .jpeg/.jpg to the URL.
@@ -325,7 +335,7 @@ To enable them, there are configuration options for each image type as well as a
 
 If either of the image handling middleware options are enabled, the [ignore_path](#ignore_path) and/or
 [ignore_request](#ignore_request) should also be configured, otherwise assets are likely to be handled
-which would likely result in 404 responses.  
+which would likely result in 404 responses.
 
 ```ruby
 # config/initializers/grover.rb
@@ -402,7 +412,7 @@ end
 ```
 
 ### allow_file_uris
-The `allow_file_uris` option can be used to render an html document from the file system. 
+The `allow_file_uris` option can be used to render an html document from the file system.
 This should be used with *EXTREME CAUTION*. If used improperly it could potentially be manipulated to reveal
 sensitive files on the system. Do not enable if rendering content from outside entities
 (user uploads, external URLs, etc).
@@ -434,6 +444,8 @@ To get around this, Grover's middleware allows you to specify relative paths for
 For direct execution, you can make multiple calls and combine the resulting PDFs together.
 
 ### Using middleware
+
+To use this functionality you need add [combine_pdf](https://rubygems.org/gems/combine_pdf) gem in your app.
 
 You can specify relative paths to the cover page contents using the `front_cover_path` and `back_cover_path`
 options either via the global configuration, or via meta tags. These paths (with query parameters) are then
@@ -560,7 +572,7 @@ The middleware and HTML preprocessing components were used heavily in the implem
 
 Thanks are also given to the excellent [Schmooze project](https://github.com/Shopify/schmooze).
 The Ruby to NodeJS interface in Grover is heavily based off that work. Grover previously used that gem,
-however migrated away due to differing requirements over persistence/cleanup of the NodeJS worker process.  
+however migrated away due to differing requirements over persistence/cleanup of the NodeJS worker process.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Grover.configure do |config|
 end
 ```
 
-#### Yarn pnp strategy
+#### Yarn PnP strategy
 
 If you are using the Yarn PnP strategy, you can override the run JS runtime for grover:
 

--- a/README.md
+++ b/README.md
@@ -445,11 +445,11 @@ For direct execution, you can make multiple calls and combine the resulting PDFs
 
 ### Using middleware
 
-Note, to use this functionality you need to add the [combine_pdf](https://rubygems.org/gems/combine_pdf) gem to your app.
-
 You can specify relative paths to the cover page contents using the `front_cover_path` and `back_cover_path`
 options either via the global configuration, or via meta tags. These paths (with query parameters) are then
 requested from the downstream app.
+
+Note, to use this functionality you need to add the [combine_pdf](https://rubygems.org/gems/combine_pdf) gem to your app.
 
 The cover pages are converted to PDF in isolation, and then combined together with the original PDF response,
 before being returned back up through the Rack stack.

--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ For direct execution, you can make multiple calls and combine the resulting PDFs
 
 ### Using middleware
 
-To use this functionality you need add [combine_pdf](https://rubygems.org/gems/combine_pdf) gem in your app.
+Note, to use this functionality you need to add the [combine_pdf](https://rubygems.org/gems/combine_pdf) gem to your app.
 
 You can specify relative paths to the cover page contents using the `front_cover_path` and `back_cover_path`
 options either via the global configuration, or via meta tags. These paths (with query parameters) are then

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ end
 
 #### Yarn pnp strategy
 
-If you ar using yarn pnp strategy, you can override how to run js runtime for grover:
+If you are using the Yarn PnP strategy, you can override the run JS runtime for grover:
 
 ```ruby
 Grover.configure do |config|

--- a/grover.gemspec
+++ b/grover.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'combine_pdf', '~> 1.0'
-  spec.add_dependency 'nokogiri', '~> 1.0'
+  spec.add_dependency 'nokogiri', '~> 1'
+
+  spec.add_development_dependency 'combine_pdf', '~> 1.0'
 end

--- a/grover.gemspec
+++ b/grover.gemspec
@@ -30,6 +30,4 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'nokogiri', '~> 1'
-
-  spec.add_development_dependency 'combine_pdf', '~> 1.0'
 end

--- a/lib/grover/configuration.rb
+++ b/lib/grover/configuration.rb
@@ -19,7 +19,7 @@ class Grover
       @use_pdf_middleware = true
       @use_png_middleware = false
       @use_jpeg_middleware = false
-      @js_runtime_bin = 'node'
+      @js_runtime_bin = ['node']
       @node_env_vars = {}
       @allow_file_uris = false
     end

--- a/lib/grover/configuration.rb
+++ b/lib/grover/configuration.rb
@@ -7,7 +7,8 @@ class Grover
   class Configuration
     attr_accessor :options, :meta_tag_prefix, :ignore_path, :ignore_request,
                   :root_url, :use_pdf_middleware, :use_png_middleware,
-                  :use_jpeg_middleware, :node_env_vars, :allow_file_uris
+                  :use_jpeg_middleware, :js_runtime_bin,
+                  :node_env_vars, :allow_file_uris
 
     def initialize
       @options = {}
@@ -18,6 +19,7 @@ class Grover
       @use_pdf_middleware = true
       @use_png_middleware = false
       @use_jpeg_middleware = false
+      @js_runtime_bin = 'node'
       @node_env_vars = {}
       @allow_file_uris = false
     end

--- a/lib/grover/configuration.rb
+++ b/lib/grover/configuration.rb
@@ -10,7 +10,7 @@ class Grover
                   :use_jpeg_middleware, :js_runtime_bin,
                   :node_env_vars, :allow_file_uris
 
-    def initialize
+    def initialize # rubocop:disable Metrics/MethodLength
       @options = {}
       @meta_tag_prefix = 'grover-'
       @ignore_path = nil

--- a/lib/grover/middleware.rb
+++ b/lib/grover/middleware.rb
@@ -141,7 +141,7 @@ class Grover
       begin
         require 'combine_pdf'
       rescue ::LoadError
-        raise Grover::Error, "You need install combine_pdf gem"
+        raise Grover::Error, 'Please add/install the "combine_pdf" gem to use the front/back cover page feature'
       end
     end
 

--- a/lib/grover/middleware.rb
+++ b/lib/grover/middleware.rb
@@ -138,11 +138,9 @@ class Grover
     end
 
     def load_combine_pdf
-      begin
-        require 'combine_pdf'
-      rescue ::LoadError
-        raise Grover::Error, 'Please add/install the "combine_pdf" gem to use the front/back cover page feature'
-      end
+      require 'combine_pdf'
+    rescue ::LoadError
+      raise Grover::Error, 'Please add/install the "combine_pdf" gem to use the front/back cover page feature'
     end
 
     def fetch_cover_pdf(path)

--- a/lib/grover/middleware.rb
+++ b/lib/grover/middleware.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'combine_pdf'
-
 class Grover
   #
   # Rack middleware for catching PDF requests and returning the upstream HTML as a PDF
@@ -132,10 +130,19 @@ class Grover
     end
 
     def add_cover_content(grover)
+      load_combine_pdf
       pdf = CombinePDF.parse grover.to_pdf
       pdf >> fetch_cover_pdf(grover.front_cover_path) if grover.show_front_cover?
       pdf << fetch_cover_pdf(grover.back_cover_path) if grover.show_back_cover?
       pdf.to_pdf
+    end
+
+    def load_combine_pdf
+      begin
+        require 'combine_pdf'
+      rescue ::LoadError
+        raise Grover::Error, "You need install combine_pdf gem"
+      end
     end
 
     def fetch_cover_pdf(path)

--- a/lib/grover/processor.rb
+++ b/lib/grover/processor.rb
@@ -33,7 +33,7 @@ class Grover
     def spawn_process
       @stdin, @stdout, @stderr, @wait_thr = Open3.popen3(
         Grover.configuration.node_env_vars,
-        'node',
+        Grover.configuration.js_runtime_bin,
         File.expand_path(File.join(__dir__, 'js/processor.cjs')),
         chdir: app_root
       )

--- a/lib/grover/processor.rb
+++ b/lib/grover/processor.rb
@@ -33,7 +33,7 @@ class Grover
     def spawn_process
       @stdin, @stdout, @stderr, @wait_thr = Open3.popen3(
         Grover.configuration.node_env_vars,
-        Grover.configuration.js_runtime_bin,
+        *Grover.configuration.js_runtime_bin,
         File.expand_path(File.join(__dir__, 'js/processor.cjs')),
         chdir: app_root
       )


### PR DESCRIPTION
## Reason for this changes

Gem `combine_pdf` needed only for middleware and only for `front_cover` and/or `back_cover` functionality. This mean, that people which use grover directly by `display_url` or raw html need to have this gem as additional dependency. Problem, that `combine_pdf` contain as deps https://github.com/caiges/Ruby-RC4 , which is not supported any more (dead dependency). 

https://github.com/boazsegev/combine_pdf?tab=readme-ov-file#unmaintained---help-wanted - `combine_pdf` also unmaintained

Maintained solutions to use `pdfunite` cli from poppler library or to use https://hexapdf.gettalong.org/examples/merging.html (paid solution)

![Screenshot 2024-11-06 at 02 25 37](https://github.com/user-attachments/assets/6eafd66a-5293-44a5-a641-ff5b8bdb6237)

By this proposal I making `combine_pdf` as optional and not install as dependency, so developers, which need middleware and `front_cover` and/or `back_cover` functionality can install it separately in application.


Also added ability to override js runtime bin, so in this case devs, which use non standard env, like yarn pnp, can override hardcoded `node` bin (example added in README). Possible fix for https://github.com/Studiosity/grover/pull/262