### PR TITLE
Include Node v24 in build suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,32 +23,32 @@ jobs:
         ruby-version: ['3.4']
         node-version: ['18']
         puppeteer-version: [
-          '18.2.1',
-          '19.11.1',
-          '20.9.0',
-          '21.9.0',
           '22.15.0',
-          '23.8.0',
+          '23.11.1',
+          '24.10.2',
         ]
         include:
           - ruby-version: '3.0'
             node-version: '18'
-            puppeteer-version: '23.8.0'
+            puppeteer-version: '24.10.2'
           - ruby-version: '3.1'
             node-version: '18'
-            puppeteer-version: '23.8.0'
+            puppeteer-version: '24.10.2'
           - ruby-version: '3.2'
             node-version: '18'
-            puppeteer-version: '23.8.0'
+            puppeteer-version: '24.10.2'
           - ruby-version: '3.3'
             node-version: '18'
-            puppeteer-version: '23.8.0'
+            puppeteer-version: '24.10.2'
           - ruby-version: '3.4'
             node-version: '20'
-            puppeteer-version: '23.8.0'
+            puppeteer-version: '24.10.2'
           - ruby-version: '3.4'
             node-version: '22'
-            puppeteer-version: '23.8.0'
+            puppeteer-version: '24.10.2'
+          - ruby-version: '3.4'
+            node-version: '24'
+            puppeteer-version: '24.10.2'
 
     steps:
       - uses: actions/checkout@v3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-rake
   - rubocop-rspec
 

--- a/lib/grover/middleware.rb
+++ b/lib/grover/middleware.rb
@@ -8,6 +8,13 @@ class Grover
   # @see https://github.com/pdfkit/pdfkit
   #
   class Middleware # rubocop:disable Metrics/ClassLength
+    PDF_REGEX = /\.pdf$/i
+    private_constant :PDF_REGEX
+    PNG_REGEX = /\.png$/i
+    private_constant :PNG_REGEX
+    JPEG_REGEX = /\.jpe?g$/i
+    private_constant :JPEG_REGEX
+
     def initialize(app, *args)
       @app = app
       @pdf_request = false
@@ -39,10 +46,6 @@ class Grover
     end
 
     private
-
-    PDF_REGEX = /\.pdf$/i
-    PNG_REGEX = /\.png$/i
-    JPEG_REGEX = /\.jpe?g$/i
 
     attr_reader :pdf_request, :png_request, :jpeg_request
 

--- a/spec/grover/processor_spec.rb
+++ b/spec/grover/processor_spec.rb
@@ -903,7 +903,7 @@ describe Grover::Processor do
             <<-HTML
               <html>
                 <head><link rel='icon' href='data:;base64,iVBORw0KGgo='></head>
-              #{'  '}
+
                 <body>
                   <p id="loading">Loading</p>
                   <p id="content" style="display: none">Loaded</p>


### PR DESCRIPTION
Include Puppeteer version 24.x
Remove deprecated Puppeteer releases from build matrix