### PR TITLE
Use the browser object to set cookies. 

### DIFF
--- a/lib/grover/js/processor.cjs
+++ b/lib/grover/js/processor.cjs
@@ -114,7 +114,7 @@ const _processPage = (async (convertAction, uriOrHtml, options) => {
     // Setting cookies
     const cookies = options.cookies; delete options.cookies
     if (Array.isArray(cookies)) {
-      await page.setCookie(...cookies);
+      await browser.setCookie(...cookies);
     }
 
     // Set caching flag (if provided)


### PR DESCRIPTION
It appears that using the page to set cookies is now deprecated.

I'm not sure if this will change the dependency graph of the gem as I'm not sure when this was actually changed, or if it's always been allowed:

https://pptr.dev/guides/cookies