### PR TITLE
Fix session isolation for remote browser WebSocket connections

### DIFF
--- a/lib/grover/js/processor.cjs
+++ b/lib/grover/js/processor.cjs
@@ -34,7 +34,7 @@ function GroverError(name, errors) {
 GroverError.prototype = Error.prototype;
 
 const _processPage = (async (convertAction, uriOrHtml, options) => {
-  let browser, page, tmpDir, wsConnection = false;
+  let browser, context, page, tmpDir, wsConnection = false;
   const requestErrors = [], pageErrors = [];
 
   const captureRequestError = (request) => {
@@ -114,7 +114,12 @@ const _processPage = (async (convertAction, uriOrHtml, options) => {
       browser = await puppeteer.launch(launchParams);
     }
 
-    page = await browser.newPage();
+    if (wsConnection) {
+      context = await browser.createBrowserContext();
+      page = await context.newPage();
+    } else {
+      page = await browser.newPage();
+    }
 
     // Basic auth
     const username = options.username; delete options.username
@@ -349,7 +354,7 @@ const _processPage = (async (convertAction, uriOrHtml, options) => {
   } finally {
     if (browser) {
       if (wsConnection) {
-        if (page) await page.close();
+        if (context) await context.close();
         await browser.disconnect();
       } else {
         await browser.close();

--- a/spec/grover/processor_spec.rb
+++ b/spec/grover/processor_spec.rb
@@ -571,27 +571,35 @@ describe Grover::Processor do
       end
 
       context 'when using a persistent remote browser, sessions are isolated between requests' do
-        let(:url_or_html) { '<html><body><script>document.write(document.cookie || "no cookies")</script></body></html>' }
-
-        around do |example|
-          # Launch a persistent Chrome instance and get its WS endpoint. We own
-          # this browser, so cookies in the default context persist across
-          # connections.
-          chrome_io = nil
-          args_json = ENV['GROVER_NO_SANDBOX'] == 'true' ? '["--no-sandbox","--disable-setuid-sandbox"]' : '[]'
-          js = <<~JS
+        let(:url_or_html) do
+          '<html><body><script>document.write(document.cookie || "no cookies")</script></body></html>'
+        end
+        let(:launch_args) { ENV['GROVER_NO_SANDBOX'] == 'true' ? '["--no-sandbox","--disable-setuid-sandbox"]' : '[]' }
+        let(:chrome_io) do
+          # Launch a persistent Chrome instance and get its WS endpoint. We own this browser,
+          # so cookies in the default context persist across connections.
+          IO.popen(['node', '-e', <<~JS], err: File::NULL)
             const puppeteer = require('puppeteer');
-            puppeteer.launch({ args: #{args_json} }).then(browser => {
+            puppeteer.launch({ args: #{launch_args} }).then(browser => {
               process.stdout.write(browser.wsEndpoint() + '\\n');
               process.on('SIGTERM', () => browser.close().then(() => process.exit(0)));
             });
           JS
-          chrome_io = IO.popen(['node', '-e', js], err: File::NULL)
-          @browser_ws_endpoint = chrome_io.gets.strip
-          example.run
-        ensure
-          Process.kill('TERM', chrome_io.pid) rescue nil
-          chrome_io.close rescue nil
+        end
+        let(:browser_ws_endpoint) { chrome_io.gets.strip }
+
+        after do
+          # Clean up the Chrome instance and IO
+          begin
+            Process.kill('TERM', chrome_io.pid)
+          rescue StandardError
+            nil
+          end
+          begin
+            chrome_io.close
+          rescue StandardError
+            nil
+          end
         end
 
         it 'does not leak cookies from one request into the next' do
@@ -599,14 +607,14 @@ describe Grover::Processor do
           # before the page's own scripts, works in both default and incognito contexts)
           first_result = processor.convert(
             method, url_or_html,
-            'browserWsEndpoint' => @browser_ws_endpoint,
+            'browserWsEndpoint' => browser_ws_endpoint,
             'evaluateOnNewDocument' => "document.cookie = 'session-secret=abc123'"
           )
           first_text = Grover::Utils.squish(PDF::Reader.new(StringIO.new(first_result)).pages.first.text)
           expect(first_text).to include 'session-secret=abc123'
 
           # Second request — the cookie from request 1 must not be visible
-          result = processor.convert method, url_or_html, 'browserWsEndpoint' => @browser_ws_endpoint
+          result = processor.convert method, url_or_html, 'browserWsEndpoint' => browser_ws_endpoint
           text = Grover::Utils.squish(PDF::Reader.new(StringIO.new(result)).pages.first.text)
           expect(text).to eq 'no cookies'
         end

--- a/spec/grover/processor_spec.rb
+++ b/spec/grover/processor_spec.rb
@@ -570,6 +570,48 @@ describe Grover::Processor do
         end
       end
 
+      context 'when using a persistent remote browser, sessions are isolated between requests' do
+        let(:url_or_html) { '<html><body><script>document.write(document.cookie || "no cookies")</script></body></html>' }
+
+        around do |example|
+          # Launch a persistent Chrome instance and get its WS endpoint. We own
+          # this browser, so cookies in the default context persist across
+          # connections.
+          chrome_io = nil
+          args_json = ENV['GROVER_NO_SANDBOX'] == 'true' ? '["--no-sandbox","--disable-setuid-sandbox"]' : '[]'
+          js = <<~JS
+            const puppeteer = require('puppeteer');
+            puppeteer.launch({ args: #{args_json} }).then(browser => {
+              process.stdout.write(browser.wsEndpoint() + '\\n');
+              process.on('SIGTERM', () => browser.close().then(() => process.exit(0)));
+            });
+          JS
+          chrome_io = IO.popen(['node', '-e', js], err: File::NULL)
+          @browser_ws_endpoint = chrome_io.gets.strip
+          example.run
+        ensure
+          Process.kill('TERM', chrome_io.pid) rescue nil
+          chrome_io.close rescue nil
+        end
+
+        it 'does not leak cookies from one request into the next' do
+          # First request sets a cookie via evaluateOnNewDocument (runs in the page JS context
+          # before the page's own scripts, works in both default and incognito contexts)
+          first_result = processor.convert(
+            method, url_or_html,
+            'browserWsEndpoint' => @browser_ws_endpoint,
+            'evaluateOnNewDocument' => "document.cookie = 'session-secret=abc123'"
+          )
+          first_text = Grover::Utils.squish(PDF::Reader.new(StringIO.new(first_result)).pages.first.text)
+          expect(first_text).to include 'session-secret=abc123'
+
+          # Second request — the cookie from request 1 must not be visible
+          result = processor.convert method, url_or_html, 'browserWsEndpoint' => @browser_ws_endpoint
+          text = Grover::Utils.squish(PDF::Reader.new(StringIO.new(result)).pages.first.text)
+          expect(text).to eq 'no cookies'
+        end
+      end
+
       unless linux_system? # It looks like the way a connection failure is handled is different on Linux systems
         context 'when passing through WS launch params without a remote browser' do
           let(:options) { { 'browserWsEndpoint' => 'ws://localhost:3000/' } }


### PR DESCRIPTION
When using `browser_ws_endpoint` to connect to a remote Chrome instance, pages are created via `browser.newPage()` in the default browser context. Cookies (and other browsing state) set during one request persist in the default context and leak into subsequent requests from other users.

This PR updates the behaviour to use `browser.createBrowserContext()` instead. This behaves like an incognito session — state is fully isolated and automatically cleared when `context.close()` is called after the request completes.

Added a test that:
1. Launches a persistent Chrome instance (simulating a remotely running Chrome) and retrieves its WS endpoint
2. Makes a first request that sets a cookie via `evaluateOnNewDocument`
3. Makes a second request with no cookies and asserts the cookie from the first request is not visible

Without the fix, the second request sees `session-secret=abc123` (bleed). With the fix it sees `no cookies`.