### PR TITLE
Add protocolTimeout support to puppeteer launch options

### DIFF
--- a/lib/grover/js/processor.cjs
+++ b/lib/grover/js/processor.cjs
@@ -110,6 +110,12 @@ const _processPage = (async (convertAction, uriOrHtml, options) => {
         launchParams.timeout = launchTimeout;
       }
 
+      // Set protocol timeout if given (controls CDP message round-trip timeout)
+      const protocolTimeout = options.protocolTimeout; delete options.protocolTimeout;
+      if (protocolTimeout !== undefined) {
+        launchParams.protocolTimeout = protocolTimeout;
+      }
+
       // Launch the browser and create a page
       browser = await puppeteer.launch(launchParams);
     }

--- a/lib/grover/options_fixer.rb
+++ b/lib/grover/options_fixer.rb
@@ -46,7 +46,7 @@ class Grover
     def fix_integer_options!
       fix_options!(
         'viewport.height', 'viewport.width',
-        'timeout', 'launch_timeout', 'request_timeout', 'convert_timeout', 'wait_for_timeout',
+        'timeout', 'launch_timeout', 'protocol_timeout', 'request_timeout', 'convert_timeout', 'wait_for_timeout',
         &:to_i
       )
     end


### PR DESCRIPTION
## Problem

Batch print jobs with large case counts can exceed Puppeteer's default 180 second CDP protocol timeout, resulting in:

```
ProtocolError: Network.enable timed out. Increase the 'protocolTimeout' setting in launch/connect calls for a higher timeout if needed.
```

This was reported in #248.

## Root cause

Puppeteer exposes `protocolTimeout` in its launch options to raise this limit, but Grover never extracted it into `launchParams` — the value would silently pass through to `page.pdf()` where Puppeteer ignores it entirely.

## Fix

Extract `protocolTimeout` from the options hash and pass it into `launchParams` before calling `puppeteer.launch()`, consistent with how `launchTimeout`, `executablePath`, and other launch options are handled.

Also adds `protocol_timeout` to the integer coercion list in `OptionsFixer` so it behaves consistently when set via HTML meta tags, which always produce string values.

## Usage

```ruby
Grover.new(html, protocol_timeout: 300_000).to_pdf
```

Or globally:

```ruby
Grover.configure do |config|
  config.options = { protocol_timeout: 300_000 }
end
```